### PR TITLE
ci: remove --getbinpkg from emerge calls

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -47,10 +47,10 @@ jobs:
         run: emerge-webrsync -q
 
       - name: Install Gentoo tooling
-        run: emerge --getbinpkg --quiet-build dev-util/pkgdev dev-util/pkgcheck
+        run: emerge --quiet-build dev-util/pkgdev dev-util/pkgcheck
 
       - name: Install Node.js
-        run: emerge --getbinpkg --quiet-build dev-lang/nodejs
+        run: emerge --quiet-build dev-lang/nodejs
 
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code


### PR DESCRIPTION
## Summary

- Remove `--getbinpkg` from both `emerge` calls in `auto-update.yml`

`PORTAGE_BINHOST` is not configured in the `gentoo/stage3` container, causing the "Install Gentoo tooling" step to fail for all matrix jobs. Dropping the flag lets emerge build from source instead.

Fixes the failing run: https://github.com/divoxx/gentoo-overlay/actions/runs/22289902554/job/64475179577

Generated with [Claude Code](https://claude.com/claude-code)