### PR TITLE
ci: install git before actions/checkout to get a proper git repo

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -38,16 +38,16 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Sync Portage tree
         run: emerge-webrsync -q
 
       - name: Install Gentoo tooling
-        run: emerge --quiet-build dev-util/pkgdev dev-util/pkgcheck
+        run: emerge --quiet-build dev-vcs/git dev-util/pkgdev dev-util/pkgcheck
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Node.js and Claude Code CLI
         run: |


### PR DESCRIPTION
## Summary

- Move `Sync Portage tree` and `Install Gentoo tooling` steps **before** `actions/checkout@v4`
- Add `dev-vcs/git` explicitly to the emerge call

## Root cause

The `gentoo/stage3:amd64-systemd` container has no git pre-installed. When `actions/checkout@v4` ran first inside the container, it detected no git in `PATH` and fell back to downloading a zip via the REST API — leaving the workspace without a `.git` directory. Every subsequent `git` command then failed with `fatal: not in a git directory`.

## Fix

By running the Portage sync and tooling installation (which now explicitly includes `dev-vcs/git`) *before* the checkout step, git is available in `PATH` when `actions/checkout` executes. It then creates a proper local git repository automatically.

Generated with [Claude Code](https://claude.com/claude-code)