### PR TITLE
ci: fix safe.directory for git config in container

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -63,8 +63,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:$GITHUB_TOKEN@github.com/$REPO.git"
 
       - name: Run ebuild-updater


### PR DESCRIPTION
## Summary

- The `gentoo/stage3` container runs as root, but the mounted workspace is owned by the runner user (uid ~1001)
- Git 2.35.2+ refuses to operate on repos owned by a different user without a `safe.directory` entry
- `actions/checkout` does add `safe.directory`, but writes it to a **temporary HOME** that is invisible to subsequent steps (container HOME is `/github/home`)
- Result: `git config user.name` and `git remote set-url` in the **Configure git** step fail with `fatal: not in a git directory`

**Fix:** explicitly add `safe.directory "$GITHUB_WORKSPACE"` to the global config at the start of the Configure git step, using the actual container HOME so subsequent git commands see it. Also switch `user.name`/`user.email` to `--global` (cleaner; doesn't require a local repo).

## Test plan

- [ ] Trigger `Auto-Update Ebuilds` via workflow_dispatch and confirm the **Configure git** step passes
- [ ] Confirm subsequent steps (Run ebuild-updater, Commit and push) succeed

Generated with [Claude Code](https://claude.com/claude-code)