### PR TITLE
ci: fix claude --print by passing prompt via stdin

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -74,11 +74,9 @@ jobs:
           PACKAGE: ${{ matrix.package }}
         run: |
           set -euo pipefail
-          timeout 3600 claude --print \
-            --allowedTools "Task,Read,Write,Edit,Bash,Glob,Grep,WebFetch,WebSearch" \
-            "Use the ebuild-updater agent to check for upstream updates and bump the ebuild \
-            for $PACKAGE if a newer version exists. Do not run pkgcheck or build \
-            verification — those are handled by a separate CI workflow."
+          echo "Use the ebuild-updater agent to check for upstream updates and bump the ebuild for $PACKAGE if a newer version exists. Do not run pkgcheck or build verification — those are handled by a separate CI workflow." \
+            | timeout 3600 claude --print \
+                --allowedTools "Task,Read,Write,Edit,Bash,Glob,Grep,WebFetch,WebSearch"
 
       - name: Check for changes
         id: changes


### PR DESCRIPTION
## Summary

- `--allowedTools` is a variadic option (`<tools...>`) that greedily consumes subsequent positional arguments — including the intended prompt string — leaving `claude --print` with no input and triggering the error: _"Input must be provided either through stdin or as a prompt argument when using --print"_
- Fix: pipe the prompt via stdin, which the error message itself explicitly supports as a valid input method

## Root cause

```sh
# Before — prompt silently consumed by variadic --allowedTools
claude --print \
  --allowedTools "Task,Read,..." \
  "this gets eaten as another tool value"

# After — unambiguous
echo "prompt text" | claude --print --allowedTools "Task,Read,..."
```

Generated with [Claude Code](https://claude.com/claude-code)