### PR TITLE
ci: pre-built image to eliminate per-run setup overhead

### DIFF
--- a/.github/Containerfile.ci
+++ b/.github/Containerfile.ci
@@ -1,0 +1,5 @@
+FROM gentoo/stage3:amd64-systemd
+
+RUN emerge-webrsync -q && \
+    emerge --quiet-build dev-vcs/git dev-util/pkgdev dev-util/pkgcheck dev-lang/nodejs && \
+    npm install -g @anthropic-ai/claude-code

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -31,31 +31,20 @@ jobs:
     needs: list-packages
     runs-on: ubuntu-latest
     container:
-      image: gentoo/stage3:amd64-systemd
+      image: ghcr.io/${{ github.repository_owner }}/gentoo-ci:latest
     strategy:
       matrix:
         package: ${{ fromJson(needs.list-packages.outputs.packages) }}
       fail-fast: false
 
     steps:
-      - name: Sync Portage tree
-        run: emerge-webrsync -q
-
-      - name: Install Gentoo tooling
-        run: emerge --quiet-build dev-vcs/git dev-util/pkgdev dev-util/pkgcheck
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Node.js and Claude Code CLI
-        run: |
-          set -euo pipefail
-          NODE_VERSION=$(curl -fsSL https://nodejs.org/dist/index.json | python3 -c "import sys,json; v=next(r for r in json.load(sys.stdin) if r['lts']); print(v['version'])")
-          curl -fsSL "https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.xz" \
-            | tar -xJ -C /usr/local --strip-components=1
-          npm install -g @anthropic-ai/claude-code
+      - name: Sync Portage tree
+        run: emerge --sync -q
 
       - name: Configure git
         env:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,48 @@
+name: Build CI Image
+
+on:
+  schedule:
+    - cron: '0 3 * * 0'   # Sundays 03:00 UTC (before auto-update at 06:00)
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/Containerfile.ci'
+  workflow_dispatch:        # allow manual trigger for testing
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to ghcr.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set date tag
+        id: date
+        run: echo "tag=$(date +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Build image
+        id: build
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: gentoo-ci
+          tags: latest ${{ steps.date.outputs.tag }}
+          containerfiles: .github/Containerfile.ci
+          context: .github/
+
+      - name: Push image
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build.outputs.image }}
+          tags: ${{ steps.build.outputs.tags }}
+          registry: ghcr.io/${{ github.repository_owner }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -51,7 +51,7 @@ jobs:
     if: needs.detect-changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     container:
-      image: gentoo/stage3:amd64
+      image: ghcr.io/${{ github.repository_owner }}/gentoo-ci:latest
     strategy:
       matrix:
         package: ${{ fromJson(needs.detect-changes.outputs.packages) }}
@@ -59,18 +59,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Sync Portage tree
-        run: emerge-webrsync -q
-
-      - name: Install Gentoo tooling
-        run: emerge --getbinpkg --quiet-build dev-util/pkgdev dev-util/pkgcheck
-
-      - name: Install Node.js
-        run: emerge --getbinpkg --quiet-build dev-lang/nodejs
-
-      - name: Install Claude Code CLI
-        run: npm install -g @anthropic-ai/claude-code
 
       - name: Run ebuild-verifier
         id: verify


### PR DESCRIPTION
## Summary

- Add `.github/Containerfile.ci` — OCI image from `gentoo/stage3:amd64-systemd` with emerge-webrsync + git, pkgdev, pkgcheck, nodejs, and claude-code baked in
- Add `.github/workflows/build-image.yml` — weekly build (Sundays 03:00 UTC) + push to `ghcr.io/divoxx/gentoo-ci` with `latest` and `YYYY-MM-DD` tags; also triggers on `Containerfile.ci` changes to `main`
- Update `auto-update.yml` — switch to pre-built image; replace webrsync + installs with a fast incremental `emerge --sync` for fresh version data
- Update `verify.yml` — switch to pre-built image; remove all setup steps (no tree sync needed for pkgcheck)

**Savings:** ~5–10 min of setup eliminated per CI run. For a public repo, ghcr.io storage and Actions minutes are free, so net cost is zero.

## Test Plan

- [ ] Trigger `build-image.yml` manually and confirm image appears at `ghcr.io/divoxx/gentoo-ci`
- [ ] Create a test PR to trigger `verify.yml` — confirm setup steps are absent, runtime drops
- [ ] Trigger `auto-update.yml` manually — confirm it uses the new image and completes successfully

Generated with [Claude Code](https://claude.com/claude-code)