### PR TITLE
ci: fix nodejs package atom in Containerfile.ci

### DIFF
--- a/.github/Containerfile.ci
+++ b/.github/Containerfile.ci
@@ -1,5 +1,5 @@
 FROM gentoo/stage3:amd64-systemd
 
 RUN emerge-webrsync -q && \
-    emerge --quiet-build dev-vcs/git dev-util/pkgdev dev-util/pkgcheck dev-lang/nodejs && \
+    emerge --quiet-build dev-vcs/git dev-util/pkgdev dev-util/pkgcheck net-libs/nodejs && \
     npm install -g @anthropic-ai/claude-code


### PR DESCRIPTION
## Summary

- `dev-lang/nodejs` does not exist in Gentoo; the correct package atom is `net-libs/nodejs`
- This caused the Build CI Image workflow to fail immediately after PR #9 was merged

## Test plan

- [ ] Build CI Image workflow completes successfully after merge

Generated with Claude Code