### PR TITLE
ci: enable npm USE flag for nodejs in CI image

### DIFF
--- a/.github/Containerfile.ci
+++ b/.github/Containerfile.ci
@@ -1,5 +1,6 @@
 FROM gentoo/stage3:amd64-systemd
 
-RUN emerge-webrsync -q && \
+RUN echo "net-libs/nodejs npm" >> /etc/portage/package.use && \
+    emerge-webrsync -q && \
     emerge --quiet-build dev-vcs/git dev-util/pkgdev dev-util/pkgcheck net-libs/nodejs && \
     npm install -g @anthropic-ai/claude-code


### PR DESCRIPTION
## Summary

- `net-libs/nodejs` on Gentoo does not install `npm` by default — the `npm` USE flag must be explicitly enabled
- The Build CI Image workflow was failing with `npm: command not found`, which left `ghcr.io/divoxx/gentoo-ci:latest` unpublished
- All downstream workflows (verify, auto-update) then failed with `manifest unknown` trying to pull that missing image

## Fix

Prepend `echo "net-libs/nodejs npm" >> /etc/portage/package.use` to the `RUN` layer in `Containerfile.ci` so `emerge` picks up the USE flag before building nodejs.

## Test plan

- [ ] Build CI Image workflow succeeds and pushes `ghcr.io/divoxx/gentoo-ci:latest`
- [ ] Manually trigger Auto-Update to confirm `manifest unknown` is gone
- [ ] Verify workflow passes on next PR with an ebuild change

Generated with [Claude Code](https://claude.com/claude-code)