### PR TITLE
ci: fix package.use path for nodejs npm USE flag

### DIFF
--- a/.github/Containerfile.ci
+++ b/.github/Containerfile.ci
@@ -1,6 +1,6 @@
 FROM gentoo/stage3:amd64-systemd
 
-RUN echo "net-libs/nodejs npm" >> /etc/portage/package.use && \
+RUN echo "net-libs/nodejs npm" >> /etc/portage/package.use/nodejs && \
     emerge-webrsync -q && \
     emerge --quiet-build dev-vcs/git dev-util/pkgdev dev-util/pkgcheck net-libs/nodejs && \
     npm install -g @anthropic-ai/claude-code


### PR DESCRIPTION
## Summary

- `/etc/portage/package.use` in the Gentoo stage3 image is a **directory**, not a file — the previous fix tried to redirect into it directly, causing `Is a directory` error
- Write to `/etc/portage/package.use/nodejs` instead (a file inside the directory)

## Test plan

- [ ] Build CI Image workflow succeeds and pushes `ghcr.io/divoxx/gentoo-ci:latest`
- [ ] Auto-Update and Verify workflows can pull the image

Generated with [Claude Code](https://claude.com/claude-code)