### PR TITLE
ci: incremental image builds using previously published image

### DIFF
--- a/.github/Containerfile.ci
+++ b/.github/Containerfile.ci
@@ -1,4 +1,5 @@
-FROM gentoo/stage3:amd64-systemd
+ARG BASE_IMAGE=gentoo/stage3:amd64-systemd
+FROM ${BASE_IMAGE}
 
 RUN echo "net-libs/nodejs npm" >> /etc/portage/package.use/nodejs && \
     emerge-webrsync -q && \

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -31,6 +31,25 @@ jobs:
         id: date
         run: echo "tag=$(date +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
 
+      - name: Pull existing image for incremental build
+        id: pull
+        continue-on-error: true
+        env:
+          REGISTRY: ghcr.io/${{ github.repository_owner }}
+        run: podman pull "$REGISTRY/gentoo-ci:latest"
+
+      - name: Set base image
+        id: base
+        env:
+          PULL_OUTCOME: ${{ steps.pull.outcome }}
+          REGISTRY: ghcr.io/${{ github.repository_owner }}
+        run: |
+          if [ "$PULL_OUTCOME" = "success" ]; then
+            echo "image=$REGISTRY/gentoo-ci:latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "image=gentoo/stage3:amd64-systemd" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build image
         id: build
         uses: redhat-actions/buildah-build@v2
@@ -39,6 +58,8 @@ jobs:
           tags: latest ${{ steps.date.outputs.tag }}
           containerfiles: .github/Containerfile.ci
           context: .github/
+          build-args: |
+            BASE_IMAGE=${{ steps.base.outputs.image }}
 
       - name: Push image
         uses: redhat-actions/push-to-registry@v2


### PR DESCRIPTION
## Summary

- Add `ARG BASE_IMAGE` to `Containerfile.ci` so the base image is configurable
- In `build-image.yml`, try to pull `ghcr.io/.../gentoo-ci:latest` before building; use it as `BASE_IMAGE` if available, otherwise fall back to `gentoo/stage3:amd64-systemd`
- Since `emerge` skips packages already at their latest version, nodejs and other tools won't be recompiled on each weekly rebuild — only packages with upstream version bumps are rebuilt

## How it works

On the first build (or after a manual reset), the pull fails and the image is built from scratch using `stage3`. On every subsequent build, the previously published image is used as the base, making the build much faster.

## Test plan

- [ ] Verify the `build-image` action succeeds after merging (this will be the first build, using `stage3`)
- [ ] Trigger the workflow again manually (`workflow_dispatch`) and confirm it uses the cached image and finishes significantly faster

🤖 Generated with [Claude Code](https://claude.com/claude-code)