### PR TITLE
ci: run auto-update on Sunday and Wednesday instead of daily

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -2,7 +2,8 @@ name: Auto-Update Ebuilds
 
 on:
   schedule:
-    - cron: '0 6 * * *'   # 06:00 UTC daily
+    - cron: '0 6 * * 0'   # Sunday 06:00 UTC (3h after image build at 03:00)
+    - cron: '0 6 * * 3'   # Wednesday 06:00 UTC
   workflow_dispatch:        # allow manual trigger for testing
 
 permissions:


### PR DESCRIPTION
## Summary

- Changes auto-update schedule from daily to Sunday + Wednesday
- Sunday run at 06:00 UTC stays 3 hours after the image build (03:00 UTC), maintaining the required buffer
- Wednesday run at 06:00 UTC (no image build dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)