### PR TITLE
rename overlay from gentoo-overlay to divoxx-overlay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Identity
 
-- **Overlay name:** `gentoo-overlay`
+- **Overlay name:** `divoxx-overlay`
 - **Type:** Gentoo package overlay
 - **EAPI:** 8 (all packages)
 - **Architecture:** `~amd64` (testing keywords only — never stable)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gentoo-overlay
+# divoxx-overlay
 
 A personal Gentoo package overlay by [Rodrigo Kochenburger](https://github.com/divoxx) containing packages not available in the [official Gentoo tree](https://packages.gentoo.org/) or the [GURU overlay](https://gpo.zugaina.org/overlays/guru).
 
@@ -18,23 +18,23 @@ A personal Gentoo package overlay by [Rodrigo Kochenburger](https://github.com/d
 ### eselect-repository (recommended)
 
 ```bash
-eselect repository add gentoo-overlay git https://github.com/divoxx/gentoo-overlay.git
-emaint sync -r gentoo-overlay
+eselect repository add divoxx-overlay git https://github.com/divoxx/gentoo-overlay.git
+emaint sync -r divoxx-overlay
 ```
 
 ### repos.conf
 
-Create `/etc/portage/repos.conf/gentoo-overlay.conf`:
+Create `/etc/portage/repos.conf/divoxx-overlay.conf`:
 
 ```ini
-[gentoo-overlay]
-location = /var/db/repos/gentoo-overlay
+[divoxx-overlay]
+location = /var/db/repos/divoxx-overlay
 sync-type = git
 sync-uri = https://github.com/divoxx/gentoo-overlay.git
 auto-sync = yes
 ```
 
-Then run `emaint sync -r gentoo-overlay`.
+Then run `emaint sync -r divoxx-overlay`.
 
 ## Contributing
 

--- a/profiles/repo_name
+++ b/profiles/repo_name
@@ -1,1 +1,1 @@
-gentoo-overlay
+divoxx-overlay


### PR DESCRIPTION
## Summary

- Updates `profiles/repo_name` (the Portage-authoritative overlay identifier) from `gentoo-overlay` to `divoxx-overlay`
- Updates `README.md` installation instructions: `eselect repository add`, `emaint sync -r`, `.conf` filename, `[section]` header, and `location` path
- Updates `CLAUDE.md` project identity line

The GitHub repository URL (`github.com/divoxx/gentoo-overlay.git`) is intentionally unchanged — the repo slug has not been renamed.

## Test plan

- [ ] `cat profiles/repo_name` outputs `divoxx-overlay`
- [ ] `grep -r "gentoo-overlay" profiles/ README.md CLAUDE.md` returns no matches (only GitHub URLs remain, which are correct)

Generated with Claude Code