### PR TITLE
ci: add dev-lang/rust-bin to gentoo-ci container image

### DIFF
--- a/.github/Containerfile.ci
+++ b/.github/Containerfile.ci
@@ -3,5 +3,5 @@ FROM ${BASE_IMAGE}
 
 RUN echo "net-libs/nodejs npm" >> /etc/portage/package.use/nodejs && \
     emerge-webrsync -q && \
-    emerge --quiet-build dev-vcs/git dev-util/pkgdev dev-util/pkgcheck net-libs/nodejs dev-lang/go && \
+    emerge --quiet-build dev-vcs/git dev-util/pkgdev dev-util/pkgcheck net-libs/nodejs dev-lang/go dev-lang/rust-bin && \
     npm install -g @anthropic-ai/claude-code


### PR DESCRIPTION
## Summary

- Add `dev-lang/rust-bin` to the `gentoo-ci` container image
- `cargo.eclass` uses Portage's `has_version` to check for a Rust toolchain — `rustc` in `PATH` alone is not sufficient
- Without this, any Rust-based ebuild (e.g. `dev-util/worktrunk`) fails the build phase in CI with "No Rust toolchain in CI environment"

## Test plan

- [ ] Rebuild and push `ghcr.io/divoxx/gentoo-ci:latest` from the updated `Containerfile.ci`
- [ ] Re-run CI on PR #20 (`dev-util/worktrunk`) — build phase should now proceed past `pkg_setup`

Generated with Claude Code