### PR TITLE
fix(exercism): fix install failure and extend CI to cover install phase

### DIFF
--- a/.claude/agents/ebuild-verifier.md
+++ b/.claude/agents/ebuild-verifier.md
@@ -1,6 +1,6 @@
 ---
 name: ebuild-verifier
-description: Verifies Gentoo ebuilds by running pkgcheck QA scans and performing a build test (compile without install).
+description: Verifies Gentoo ebuilds by running pkgcheck QA scans and performing a build test (compile and install).
 tools:
   - Read
   - Bash
@@ -66,14 +66,14 @@ ebuild <path-to-ebuild> clean fetch >/tmp/fetch.log 2>&1 \
 **Step 2 — build phases** (run synchronously, capture output directly):
 
 ```bash
-ebuild <path-to-ebuild> unpack prepare configure compile
+ebuild <path-to-ebuild> unpack prepare configure compile install
 ```
 
-This builds the package through the compile phase without merging it to the live filesystem.
+This builds the package through the install phase. The `install` phase writes into a staging image directory (`${D}`) and does not touch the live filesystem. Do NOT run the `merge` phase.
 
-- Report success or failure of each phase: `unpack`, `prepare`, `configure`, `compile`.
+- Report success or failure of each phase: `unpack`, `prepare`, `configure`, `compile`, `install`.
 - If the build fails, examine the error output, identify the cause (missing dependency, patch failure, configure error, compiler error, etc.), and report it clearly.
-- Do NOT run `install` or `merge` phases.
+- Do NOT run the `merge` phase.
 
 ### 5. Report
 
@@ -94,6 +94,7 @@ Provide a structured summary:
 - prepare:   [OK / FAILED]
 - configure: [OK / FAILED]
 - compile:   [OK / FAILED]
+- install:   [OK / FAILED]
 
 ### Overall: PASS / FAIL
 <Summary of any action required>

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -80,7 +80,7 @@ jobs:
           timeout 1800 claude --print \
             "Use the ebuild-verifier agent to run full verification for $PACKAGE. \
             Regenerate the Manifest if needed, run pkgcheck QA scan, and build through the \
-            compile phase without installing. Report results." \
+            install phase without merging to the live filesystem. Report results." \
             --allowedTools "Agent,Read,Bash,Glob,Grep" | tee "$OUTFILE"
 
           if grep -qE "Overall:.*PASS" "$OUTFILE"; then

--- a/dev-util/exercism/exercism-3.5.8.ebuild
+++ b/dev-util/exercism/exercism-3.5.8.ebuild
@@ -515,10 +515,10 @@ SLOT="0"
 KEYWORDS="~amd64"
 
 src_compile() {
-	ego build -o exercism ./exercism
+	ego build -o bin/exercism ./exercism
 }
 
 src_install() {
-	dobin exercism
+	dobin bin/exercism
 	dodoc README.md
 }


### PR DESCRIPTION
## Summary

- Fix `dev-util/exercism-3.5.8` install failure: `ego build -o exercism ./exercism` caused Go to treat the `-o` target as a directory (the `exercism/` source subdirectory already existed), placing the binary at `exercism/exercism` instead of a plain file — `dobin exercism` then failed. Fixed by using `bin/exercism` as the output path.
- Extend `ebuild-verifier` agent and CI verify workflow to run through the `install` phase (safe — writes to staging `${D}`, not the live filesystem), closing the gap that allowed this class of bug to pass CI undetected.

## Test plan

- [ ] Verify `emerge =dev-util/exercism-3.5.8` completes successfully
- [ ] Confirm CI verify job runs through `install` phase and reports it in the summary
- [ ] Confirm existing packages still pass the updated verifier

Generated with Claude Code