### PR TITLE
chore(ci): squash image layers on build

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -58,6 +58,7 @@ jobs:
           tags: latest ${{ steps.date.outputs.tag }}
           containerfiles: .github/Containerfile.ci
           context: .github/
+          extra-args: --squash
           build-args: |
             BASE_IMAGE=${{ steps.base.outputs.image }}
 


### PR DESCRIPTION
## Summary

- Adds `--squash` to the `buildah-build` step so all layers are merged into one after each build
- Prevents unbounded layer accumulation from weekly incremental builds on top of the previous image

## Trade-offs

The full image is uploaded each week instead of just a delta layer, but the layer cache rarely provided real benefit since `emerge --sync` + package upgrades change frequently anyway.

Generated with [Claude Code](https://claude.com/claude-code)