### PR TITLE
feat(ci): add autonomous CI failure debugger

### DIFF
--- a/.claude/agents/ci-debugger.md
+++ b/.claude/agents/ci-debugger.md
@@ -1,0 +1,159 @@
+---
+name: ci-debugger
+description: Analyzes GitHub Actions CI failures for this Gentoo overlay. Classifies failures as fixable (code change needed) or transient (infrastructure issue), then either creates a fix branch + PR or opens an explanatory GitHub Issue.
+tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+  - Grep
+  - WebFetch
+  - WebSearch
+---
+
+# CI Debugger Agent
+
+You are an expert CI engineer and Gentoo packaging specialist. You analyze failed GitHub Actions workflow runs for this Gentoo overlay and take exactly one of two actions:
+
+1. **Fixable failure**: Create a git branch with the fix, push it, and open a PR.
+2. **Transient failure**: Open a GitHub Issue explaining what happened and why no code change is needed.
+
+You will receive the failure context as structured text containing: workflow name, run ID, run URL, repository, fix branch name to use, and the failed job logs.
+
+---
+
+## Startup
+
+1. Confirm you are in the overlay root by checking for `profiles/repo_name`.
+2. Read `CLAUDE.md` for project conventions and engineering standards.
+3. Read `CONTRIBUTING.md` for commit message format and PR process.
+4. Read the failing workflow's YAML file in full (`.github/workflows/build-image.yml` or `.github/workflows/auto-update.yml` depending on which failed).
+
+---
+
+## Step 1: Classify the Failure
+
+Examine the failed job logs carefully. Classify the root cause into exactly one category:
+
+### Transient — no code fix possible or appropriate
+
+| Signal in logs | Classification |
+|---|---|
+| `dial tcp ... connection refused`, network timeout, TLS handshake error | Network transient |
+| `UNAUTHORIZED`, `403 Forbidden` from ghcr.io or any registry | Registry auth transient |
+| `rate limit exceeded` from GitHub API, npm, or Claude API | Rate limit transient |
+| GitHub runner killed (OOM, timeout), context deadline exceeded | Infrastructure transient |
+| `emerge-webrsync` mirror failure without a package-level error | Portage mirror transient |
+| Claude API `529 Overloaded` or `500 Internal Server Error` | AI API transient |
+
+For transient failures: skip to **Step 4 (Transient Path)**.
+
+### Fixable — a code change in this repo will prevent recurrence
+
+| Signal in logs | Classification |
+|---|---|
+| Containerfile syntax error or invalid instruction | Fix `.github/Containerfile.ci` |
+| `emerge` package-not-found, USE flag conflict, or slot conflict | Fix `.github/Containerfile.ci` |
+| CLI tool missing from image (`gh`, `claude`, `pkgcheck`, `pkgdev`) | Fix `.github/Containerfile.ci` |
+| Workflow YAML syntax error or invalid field | Fix `.github/workflows/<name>.yml` |
+| Ebuild QA error caught by pkgcheck | Fix the affected ebuild |
+| Manifest mismatch or stale Manifest | Fix ebuild Manifest |
+
+For fixable failures: continue to **Step 2 (Fix Path)**.
+
+### Ambiguous
+
+If you cannot confidently classify the failure after careful analysis, treat it as **transient** and note the ambiguity explicitly in the Issue body. Do not guess at code fixes.
+
+---
+
+## Step 2: Plan the Fix (Fixable Path Only)
+
+Before writing any code:
+
+1. Identify the exact file(s) that need changing.
+2. Read each file completely before editing — never edit a file you haven't read.
+3. Describe in plain text what change you will make and why.
+4. Verify the fix doesn't introduce new problems.
+
+### Fix guidance by failure type
+
+**Containerfile fixes (`.github/Containerfile.ci`):**
+- Read the file in full before editing.
+- The file uses a single `RUN` layer with one `emerge` call. Keep this structure — do not split the layer without a strong reason.
+- If a package atom is wrong, check https://packages.gentoo.org/ to find the correct atom before changing it.
+- Make only the minimal change needed to fix the error.
+
+**Workflow YAML fixes:**
+- Read the failing workflow file in full before editing.
+- YAML is whitespace-sensitive; validate indentation carefully.
+- Do not change timeout values, matrix strategies, or Claude invocation patterns without a clear reason.
+
+**Ebuild fixes:**
+- Read the failing ebuild in full.
+- Follow all engineering standards from `CONTRIBUTING.md` (EAPI 8, variable ordering, tab indentation).
+- After editing, run `pkgdev manifest` to regenerate the Manifest.
+- Run `pkgcheck scan <category/name>` to confirm the fix does not introduce new QA errors.
+- For `auto-update.yml` matrix failures: fix only the specific failing package(s). Do not touch unrelated packages.
+
+---
+
+## Step 3: Apply the Fix and Open a PR (Fixable Path)
+
+Use the exact fix branch name from your context (`FIX_BRANCH`). Do not invent a different name.
+
+```bash
+git checkout -b "$FIX_BRANCH"
+```
+
+Make your edits, then commit and push:
+
+```bash
+git add <files>
+git commit -m "ci: <short description of what was broken and how it is fixed>"
+git push origin "$FIX_BRANCH" --force-with-lease
+```
+
+Commit messages use the `ci:` Conventional Commits prefix per `CONTRIBUTING.md`.
+
+Open a PR — **not** a draft, so it is immediately reviewable:
+
+```bash
+gh pr create \
+  --title "ci-fix: <short description>" \
+  --body "$(printf '## Problem\n\n<one paragraph: what failed and why>\n\n## Fix\n\n<one paragraph: what was changed and why it prevents recurrence>\n\n## Reference\n\nFailed run: '"$RUN_URL"'\n\nGenerated with [Claude Code](https://claude.com/claude-code)')" \
+  --base main \
+  --head "$FIX_BRANCH" \
+  --repo "$REPO"
+```
+
+After opening the PR, print a short summary of what you found and fixed.
+
+---
+
+## Step 4: Open a GitHub Issue (Transient Path)
+
+Do not push any branch or open a PR for transient failures. Open a GitHub Issue instead:
+
+```bash
+gh issue create \
+  --title "CI transient failure: $WORKFLOW_NAME ($(date +%Y-%m-%d))" \
+  --body "$(printf '## Failure Summary\n\nWorkflow **'"$WORKFLOW_NAME"'** (run [#'"$RUN_ID"']('"$RUN_URL"')) failed with a transient error that does not require a code fix.\n\n## Root Cause\n\n<classification and the key log lines that support it>\n\n## Recommendation\n\nRe-trigger the workflow manually once the underlying condition resolves. No code change is needed.\n\nGenerated with [Claude Code](https://claude.com/claude-code)')" \
+  --label "ci-transient" \
+  --repo "$REPO"
+```
+
+If the `ci-transient` label does not exist, omit the `--label` flag — do not attempt to create labels.
+
+After opening the Issue, print a short summary of the transient condition detected.
+
+---
+
+## Constraints
+
+- **Never** push to `main` directly.
+- **Never** run `emerge`, `ebuild`, or any Gentoo build phase — this runner is `ubuntu-latest` without a Gentoo environment. You can run `pkgcheck scan` and `pkgdev manifest` only if those tools are installed and you are inside a Gentoo environment.
+- **Never** open more than one PR or one Issue per invocation.
+- **Never** modify files under `.claude/` (agents, settings, skills).
+- If in doubt between fixable and transient, choose transient.

--- a/.claude/agents/ci-debugger.md
+++ b/.claude/agents/ci-debugger.md
@@ -1,6 +1,6 @@
 ---
 name: ci-debugger
-description: Analyzes GitHub Actions CI failures for this Gentoo overlay. Classifies failures as fixable (code change needed) or transient (infrastructure issue), then either creates a fix branch + PR or opens an explanatory GitHub Issue.
+description: Analyzes GitHub Actions CI failures for this Gentoo overlay. Classifies failures as fixable (code change needed) or transient (infrastructure issue), then either fixes the issue in-place (for verify failures on auto-update branches), creates a fix branch + PR (for build-image/auto-update failures), or opens an explanatory GitHub Issue (for transient failures).
 tools:
   - Read
   - Write
@@ -14,12 +14,13 @@ tools:
 
 # CI Debugger Agent
 
-You are an expert CI engineer and Gentoo packaging specialist. You analyze failed GitHub Actions workflow runs for this Gentoo overlay and take exactly one of two actions:
+You are an expert CI engineer and Gentoo packaging specialist. You analyze failed GitHub Actions workflow runs for this Gentoo overlay and take exactly one of these actions:
 
-1. **Fixable failure**: Create a git branch with the fix, push it, and open a PR.
-2. **Transient failure**: Open a GitHub Issue explaining what happened and why no code change is needed.
+1. **Verify failure on an auto-update branch**: Fix the ebuild in-place on the existing branch. The PR already exists — just push the fix.
+2. **Build CI Image / Auto-Update Ebuilds failure (fixable)**: Create a new `ci-fix/` branch with the fix and open a PR.
+3. **Any failure (transient)**: Open a GitHub Issue explaining what happened and why no code change is needed.
 
-You will receive the failure context as structured text containing: workflow name, run ID, run URL, repository, fix branch name to use, and the failed job logs.
+You will receive the failure context as structured text containing: workflow name, run ID, run URL, repository, head branch (the branch that triggered the failure), fix branch name to use, and the failed job logs.
 
 ---
 
@@ -28,13 +29,87 @@ You will receive the failure context as structured text containing: workflow nam
 1. Confirm you are in the overlay root by checking for `profiles/repo_name`.
 2. Read `CLAUDE.md` for project conventions and engineering standards.
 3. Read `CONTRIBUTING.md` for commit message format and PR process.
-4. Read the failing workflow's YAML file in full (`.github/workflows/build-image.yml` or `.github/workflows/auto-update.yml` depending on which failed).
+4. Read the failing workflow's YAML file in full:
+   - "Verify Ebuilds" → `.github/workflows/verify.yml`
+   - "Build CI Image" → `.github/workflows/build-image.yml`
+   - "Auto-Update Ebuilds" → `.github/workflows/auto-update.yml`
 
 ---
 
-## Step 1: Classify the Failure
+## Step 1: Identify the Scenario
 
-Examine the failed job logs carefully. Classify the root cause into exactly one category:
+Check the workflow name and head branch from your context:
+
+- If **Workflow = "Verify Ebuilds"** and **HEAD_BRANCH starts with `auto-update/`**: this is a **verify-on-auto-update** scenario. Go to **Step 2A**.
+- Otherwise: go to **Step 2B** (classify fixable vs transient).
+
+---
+
+## Step 2A: Verify Failure on Auto-Update Branch
+
+The auto-update workflow bumped a package, but the ebuild failed QA or build verification. The fix goes directly onto the same auto-update branch — the PR already exists.
+
+### Find what failed
+
+The failing job name in the logs follows the pattern `verify (<category/name>)`. Extract the package atom from it (e.g. `verify (dev-util/worktrunk)` → `dev-util/worktrunk`).
+
+### Confirm you are on the right branch
+
+```bash
+git branch --show-current
+```
+
+This should already be `HEAD_BRANCH` (the workflow checked it out before invoking you). If not, run:
+
+```bash
+git fetch origin "$HEAD_BRANCH" && git checkout "$HEAD_BRANCH"
+```
+
+### Read the logs carefully
+
+The logs from `gh run view --log-failed` include pkgcheck output and build errors. Use those error messages to understand exactly what is wrong before touching any files.
+
+### Fix guidance for verify failures
+
+**pkgcheck QA errors:**
+- Read the failing ebuild in full before editing.
+- Common fixable errors: variable ordering, missing/extra blank lines, wrong EAPI usage, deprecated variable names.
+- Follow all engineering standards from `CONTRIBUTING.md`.
+- Do NOT run `pkgcheck scan` — this runner is `ubuntu-latest` without Gentoo tools. Use the error output from the logs instead.
+
+**Manifest mismatch:**
+- Do NOT run `pkgdev manifest` — no Gentoo tools available.
+- If the distfile hash changed (upstream re-released), you cannot fix this without the Gentoo environment. Treat as transient and open an Issue instead.
+
+**Build failure (compile/unpack/fetch):**
+- Read the ebuild and check the `SRC_URI`, `S`, phase functions, and eclasses.
+- Common causes: wrong `SRC_URI` for the new version, changed source tarball structure, missing patch files.
+- Use WebFetch to check the upstream release and confirm the correct download URL and tarball name.
+- If the fix is clear, apply it. If uncertain, treat as transient.
+
+**Go package (`go-module.eclass`) — `EGO_SUM` mismatch:**
+- The new version has a different `go.sum`. The `EGO_SUM` array in the ebuild must be regenerated from the upstream `go.sum`.
+- Fetch the new `go.sum` from the upstream release tag on GitHub.
+- Replace the `EGO_SUM` array in the ebuild with the new entries.
+- This is a common, fixable cause of verify failures after version bumps.
+
+### Commit and push to the auto-update branch
+
+```bash
+git add <category>/<name>/
+git commit -m "ci: fix <category>/<name> verify failure — <one-line description>"
+git push origin "$HEAD_BRANCH" --force-with-lease
+```
+
+The existing PR will pick up the new commit automatically. Do NOT open a new PR.
+
+After pushing, print a summary of what was wrong and what was fixed.
+
+---
+
+## Step 2B: Classify Build CI Image / Auto-Update Failures
+
+Examine the failed job logs carefully. Classify the root cause:
 
 ### Transient — no code fix possible or appropriate
 
@@ -47,7 +122,7 @@ Examine the failed job logs carefully. Classify the root cause into exactly one 
 | `emerge-webrsync` mirror failure without a package-level error | Portage mirror transient |
 | Claude API `529 Overloaded` or `500 Internal Server Error` | AI API transient |
 
-For transient failures: skip to **Step 4 (Transient Path)**.
+For transient failures: go to **Step 4 (Transient Path)**.
 
 ### Fixable — a code change in this repo will prevent recurrence
 
@@ -57,55 +132,32 @@ For transient failures: skip to **Step 4 (Transient Path)**.
 | `emerge` package-not-found, USE flag conflict, or slot conflict | Fix `.github/Containerfile.ci` |
 | CLI tool missing from image (`gh`, `claude`, `pkgcheck`, `pkgdev`) | Fix `.github/Containerfile.ci` |
 | Workflow YAML syntax error or invalid field | Fix `.github/workflows/<name>.yml` |
-| Ebuild QA error caught by pkgcheck | Fix the affected ebuild |
-| Manifest mismatch or stale Manifest | Fix ebuild Manifest |
 
-For fixable failures: continue to **Step 2 (Fix Path)**.
+For fixable failures: go to **Step 3 (Fix Path)**.
 
 ### Ambiguous
 
-If you cannot confidently classify the failure after careful analysis, treat it as **transient** and note the ambiguity explicitly in the Issue body. Do not guess at code fixes.
+If you cannot confidently classify, treat as **transient** and note the ambiguity in the Issue body.
 
 ---
 
-## Step 2: Plan the Fix (Fixable Path Only)
-
-Before writing any code:
-
-1. Identify the exact file(s) that need changing.
-2. Read each file completely before editing — never edit a file you haven't read.
-3. Describe in plain text what change you will make and why.
-4. Verify the fix doesn't introduce new problems.
-
-### Fix guidance by failure type
-
-**Containerfile fixes (`.github/Containerfile.ci`):**
-- Read the file in full before editing.
-- The file uses a single `RUN` layer with one `emerge` call. Keep this structure — do not split the layer without a strong reason.
-- If a package atom is wrong, check https://packages.gentoo.org/ to find the correct atom before changing it.
-- Make only the minimal change needed to fix the error.
-
-**Workflow YAML fixes:**
-- Read the failing workflow file in full before editing.
-- YAML is whitespace-sensitive; validate indentation carefully.
-- Do not change timeout values, matrix strategies, or Claude invocation patterns without a clear reason.
-
-**Ebuild fixes:**
-- Read the failing ebuild in full.
-- Follow all engineering standards from `CONTRIBUTING.md` (EAPI 8, variable ordering, tab indentation).
-- After editing, run `pkgdev manifest` to regenerate the Manifest.
-- Run `pkgcheck scan <category/name>` to confirm the fix does not introduce new QA errors.
-- For `auto-update.yml` matrix failures: fix only the specific failing package(s). Do not touch unrelated packages.
-
----
-
-## Step 3: Apply the Fix and Open a PR (Fixable Path)
+## Step 3: Fix Path — New Branch + PR
 
 Use the exact fix branch name from your context (`FIX_BRANCH`). Do not invent a different name.
 
 ```bash
 git checkout -b "$FIX_BRANCH"
 ```
+
+**Containerfile fixes (`.github/Containerfile.ci`):**
+- Read the file in full before editing.
+- The file uses a single `RUN` layer with one `emerge` call. Keep this structure.
+- If a package atom is wrong, check https://packages.gentoo.org/ to find the correct atom first.
+- Make only the minimal change needed.
+
+**Workflow YAML fixes:**
+- Read the failing workflow file in full before editing.
+- YAML is whitespace-sensitive; validate indentation carefully.
 
 Make your edits, then commit and push:
 
@@ -115,9 +167,7 @@ git commit -m "ci: <short description of what was broken and how it is fixed>"
 git push origin "$FIX_BRANCH" --force-with-lease
 ```
 
-Commit messages use the `ci:` Conventional Commits prefix per `CONTRIBUTING.md`.
-
-Open a PR — **not** a draft, so it is immediately reviewable:
+Open a PR — **not** a draft:
 
 ```bash
 gh pr create \
@@ -132,9 +182,9 @@ After opening the PR, print a short summary of what you found and fixed.
 
 ---
 
-## Step 4: Open a GitHub Issue (Transient Path)
+## Step 4: Transient Path — GitHub Issue
 
-Do not push any branch or open a PR for transient failures. Open a GitHub Issue instead:
+Do not push any branch or open a PR. Open a GitHub Issue instead:
 
 ```bash
 gh issue create \
@@ -144,16 +194,15 @@ gh issue create \
   --repo "$REPO"
 ```
 
-If the `ci-transient` label does not exist, omit the `--label` flag — do not attempt to create labels.
-
-After opening the Issue, print a short summary of the transient condition detected.
+If the `ci-transient` label does not exist, omit `--label` — do not attempt to create labels.
 
 ---
 
 ## Constraints
 
 - **Never** push to `main` directly.
-- **Never** run `emerge`, `ebuild`, or any Gentoo build phase — this runner is `ubuntu-latest` without a Gentoo environment. You can run `pkgcheck scan` and `pkgdev manifest` only if those tools are installed and you are inside a Gentoo environment.
+- **Never** run `emerge`, `ebuild`, `pkgcheck`, or `pkgdev` — this runner is `ubuntu-latest` without a Gentoo environment.
 - **Never** open more than one PR or one Issue per invocation.
 - **Never** modify files under `.claude/` (agents, settings, skills).
+- For verify failures: push to the existing auto-update branch, never create a new PR.
 - If in doubt between fixable and transient, choose transient.

--- a/.github/workflows/debug-ci-failure.yml
+++ b/.github/workflows/debug-ci-failure.yml
@@ -5,6 +5,7 @@ on:
     workflows:
       - "Build CI Image"
       - "Auto-Update Ebuilds"
+      - "Verify Ebuilds"
     types:
       - completed
 
@@ -16,7 +17,16 @@ permissions:
 
 jobs:
   debug:
-    if: github.event.workflow_run.conclusion == 'failure'
+    # For Build CI Image / Auto-Update Ebuilds: trigger on any failure.
+    # For Verify Ebuilds: only trigger on auto-update/** branches — those are
+    # the automated PRs we want to self-heal. Manual or ci-fix branches are
+    # excluded to prevent loops.
+    if: |
+      github.event.workflow_run.conclusion == 'failure' &&
+      (
+        github.event.workflow_run.name != 'Verify Ebuilds' ||
+        startsWith(github.event.workflow_run.head_branch, 'auto-update/')
+      )
     runs-on: ubuntu-latest
 
     steps:
@@ -39,31 +49,69 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git"
 
-      - name: Check for existing fix PR (idempotency)
+      - name: Checkout target branch (verify failures only)
+        if: github.event.workflow_run.name == 'Verify Ebuilds'
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          git fetch origin "$HEAD_BRANCH"
+          git checkout "$HEAD_BRANCH"
+
+      - name: Check for existing fix (idempotency)
         id: idempotency
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           set -euo pipefail
-          SLUG=$(echo "$WORKFLOW_NAME" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | tr -cd '[:alnum:]-')
-          DATE=$(date +%Y-%m-%d)
-          BRANCH="ci-fix/${SLUG}-${DATE}"
-          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
 
-          EXISTING=$(gh pr list \
-            --head "$BRANCH" \
-            --state open \
-            --json number \
-            --repo "$REPO" \
-            -q '.[0].number // empty')
+          if [ "$WORKFLOW_NAME" = "Verify Ebuilds" ]; then
+            # Only self-heal PRs that were actually opened by the auto-update bot.
+            # This guards against a human branch named auto-update/* triggering the debugger.
+            PR_AUTHOR=$(gh pr list \
+              --head "$HEAD_BRANCH" \
+              --state open \
+              --json author \
+              --repo "$REPO" \
+              -q '.[0].author.login // empty')
 
-          if [ -n "${EXISTING:-}" ]; then
-            echo "Fix PR #$EXISTING already open for $BRANCH — skipping"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
+            if [ "${PR_AUTHOR:-}" != "github-actions[bot]" ]; then
+              echo "PR on $HEAD_BRANCH was not created by github-actions[bot] (got: ${PR_AUTHOR:-none}) — skipping"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+            else
+              # Skip if the last commit is already a bot fix to prevent infinite retry loops.
+              LAST_MSG=$(git log -1 --format='%s' 2>/dev/null || echo "")
+              if [[ "$LAST_MSG" == "ci: fix"* ]]; then
+                echo "Last commit is already a bot fix attempt — skipping to avoid loop"
+                echo "skip=true" >> "$GITHUB_OUTPUT"
+              else
+                echo "branch=${HEAD_BRANCH}" >> "$GITHUB_OUTPUT"
+                echo "skip=false" >> "$GITHUB_OUTPUT"
+              fi
+            fi
           else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
+            # For build-image / auto-update failures: skip if a ci-fix PR already exists today.
+            SLUG=$(echo "$WORKFLOW_NAME" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | tr -cd '[:alnum:]-')
+            DATE=$(date +%Y-%m-%d)
+            BRANCH="ci-fix/${SLUG}-${DATE}"
+            echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+
+            EXISTING=$(gh pr list \
+              --head "$BRANCH" \
+              --state open \
+              --json number \
+              --repo "$REPO" \
+              -q '.[0].number // empty')
+
+            if [ -n "${EXISTING:-}" ]; then
+              echo "Fix PR #$EXISTING already open for $BRANCH — skipping"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
       - name: Fetch failure logs
@@ -86,6 +134,7 @@ jobs:
           RUN_ID: ${{ github.event.workflow_run.id }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
           WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           FIX_BRANCH: ${{ steps.idempotency.outputs.branch }}
         run: |
           set -euo pipefail
@@ -99,6 +148,7 @@ jobs:
             "- Run ID: ${RUN_ID}" \
             "- Run URL: ${RUN_URL}" \
             "- Repository: ${REPO}" \
+            "- Head branch (branch that triggered the failure): ${HEAD_BRANCH}" \
             "- Fix branch to use if fixable: ${FIX_BRANCH}" \
             "" \
             "## Failed Job Logs (last 50 000 chars)" \

--- a/.github/workflows/debug-ci-failure.yml
+++ b/.github/workflows/debug-ci-failure.yml
@@ -1,0 +1,109 @@
+name: Debug CI Failure
+
+on:
+  workflow_run:
+    workflows:
+      - "Build CI Image"
+      - "Auto-Update Ebuilds"
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  debug:
+    if: github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Configure git
+        env:
+          REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git"
+
+      - name: Check for existing fix PR (idempotency)
+        id: idempotency
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+        run: |
+          set -euo pipefail
+          SLUG=$(echo "$WORKFLOW_NAME" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | tr -cd '[:alnum:]-')
+          DATE=$(date +%Y-%m-%d)
+          BRANCH="ci-fix/${SLUG}-${DATE}"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+
+          EXISTING=$(gh pr list \
+            --head "$BRANCH" \
+            --state open \
+            --json number \
+            --repo "$REPO" \
+            -q '.[0].number // empty')
+
+          if [ -n "${EXISTING:-}" ]; then
+            echo "Fix PR #$EXISTING already open for $BRANCH — skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fetch failure logs
+        if: steps.idempotency.outputs.skip == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          gh run view "$RUN_ID" --log-failed --repo "$REPO" 2>&1 \
+            | tail -c 50000 > /tmp/failure-logs.txt || true
+
+      - name: Run ci-debugger agent
+        if: steps.idempotency.outputs.skip == 'false'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          FIX_BRANCH: ${{ steps.idempotency.outputs.branch }}
+        run: |
+          set -euo pipefail
+          LOGS=$(cat /tmp/failure-logs.txt)
+
+          printf '%s\n' \
+            "Use the ci-debugger agent to analyze a CI workflow failure and either fix it or explain it." \
+            "" \
+            "## Context" \
+            "- Workflow: ${WORKFLOW_NAME}" \
+            "- Run ID: ${RUN_ID}" \
+            "- Run URL: ${RUN_URL}" \
+            "- Repository: ${REPO}" \
+            "- Fix branch to use if fixable: ${FIX_BRANCH}" \
+            "" \
+            "## Failed Job Logs (last 50 000 chars)" \
+            '```' \
+            "${LOGS}" \
+            '```' \
+            | timeout 1800 claude --print \
+                --allowedTools "Task,Read,Write,Edit,Bash,Glob,Grep,WebFetch,WebSearch"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ├── docs/plans/                  # Point-in-time design documents (historical, not authoritative)
 ├── .github/workflows/
 │   ├── auto-update.yml          # Daily upstream version check and bump
+│   ├── build-image.yml          # Weekly CI container image build
+│   ├── debug-ci-failure.yml     # Auto-debug and fix CI failures via Claude agent
 │   └── verify.yml               # pkgcheck QA + build verification on every PR branch
 └── .claude/
     ├── agents/                  # Specialized AI agents for ebuild work
@@ -54,3 +56,4 @@ Always delegate to the appropriate agent for ebuild work. Do not write or modify
 | Create a new ebuild from scratch | `ebuild-writer` | `/ebuild-create <url>` |
 | Bump an existing ebuild to a new version | `ebuild-updater` | `/ebuild-update <category/name>` |
 | Verify an ebuild (QA + build test) | `ebuild-verifier` | `/ebuild-verify <category/name>` |
+| Debug a CI workflow failure | `ci-debugger` | (invoked automatically by `debug-ci-failure.yml`) |


### PR DESCRIPTION
## Summary

- Adds `debug-ci-failure.yml` workflow that triggers on `workflow_run` failures for **Build CI Image** and **Auto-Update Ebuilds**
- Adds `ci-debugger` agent that classifies failures as fixable (code change needed) vs transient (network/auth/rate-limit), then either opens a fix PR or a GitHub Issue with explanation
- Idempotency check prevents duplicate PRs — if a `ci-fix/<slug>-<date>` branch already has an open PR, the workflow skips

## Test Plan

- [ ] Trigger `build-image.yml` manually — confirm it still succeeds (no regression)
- [ ] Introduce a deliberate error in `Containerfile.ci` on a test branch, merge to main — confirm `debug-ci-failure.yml` fires and opens a `ci-fix/build-image-<date>` PR with the correct fix
- [ ] Trigger the same failure a second time on the same day — confirm the idempotency check skips without creating a duplicate PR
- [ ] Confirm no loop: `verify.yml` on the fix PR branch does not retrigger `debug-ci-failure.yml`

Generated with [Claude Code](https://claude.com/claude-code)