### PR TITLE
fix(ci): fail the debug job when ci-debugger does not complete successfully

### DIFF
--- a/.claude/agents/ci-debugger.md
+++ b/.claude/agents/ci-debugger.md
@@ -236,5 +236,6 @@ echo "failure: <one-line reason>" > /tmp/ci-debugger-result
 - **Never** run `emerge`, `ebuild`, `pkgcheck`, or `pkgdev` — this runner is `ubuntu-latest` without a Gentoo environment.
 - **Never** open more than one PR or one Issue per invocation.
 - **Never** modify files under `.claude/` (agents, settings, skills).
+- **Never** modify files under `.github/workflows/` — `GITHUB_TOKEN` cannot push workflow file changes (requires a PAT with `workflow` scope). If the fix requires a workflow change, open a GitHub Issue describing the needed change instead of attempting a push.
 - For verify failures: push to the existing auto-update branch, never create a new PR.
 - If in doubt between fixable and transient, choose transient.

--- a/.claude/agents/ci-debugger.md
+++ b/.claude/agents/ci-debugger.md
@@ -103,7 +103,17 @@ git push origin "$HEAD_BRANCH" --force-with-lease
 
 The existing PR will pick up the new commit automatically. Do NOT open a new PR.
 
-After pushing, print a summary of what was wrong and what was fixed.
+After a successful push, write the result and print a summary:
+
+```bash
+echo "success: fix pushed to $HEAD_BRANCH" > /tmp/ci-debugger-result
+```
+
+If the push fails or you cannot determine a fix, write a failure result before stopping:
+
+```bash
+echo "failure: <one-line reason>" > /tmp/ci-debugger-result
+```
 
 ---
 
@@ -178,7 +188,17 @@ gh pr create \
   --repo "$REPO"
 ```
 
-After opening the PR, print a short summary of what you found and fixed.
+After a successful push and PR creation, write the result and print a summary:
+
+```bash
+echo "success: PR opened at <pr-url>" > /tmp/ci-debugger-result
+```
+
+If the push or PR creation fails, write a failure result before stopping:
+
+```bash
+echo "failure: <one-line reason>" > /tmp/ci-debugger-result
+```
 
 ---
 
@@ -195,6 +215,18 @@ gh issue create \
 ```
 
 If the `ci-transient` label does not exist, omit `--label` — do not attempt to create labels.
+
+After a successful issue creation, write the result:
+
+```bash
+echo "success: transient issue opened" > /tmp/ci-debugger-result
+```
+
+If issue creation fails, write a failure result before stopping:
+
+```bash
+echo "failure: <one-line reason>" > /tmp/ci-debugger-result
+```
 
 ---
 

--- a/.github/workflows/debug-ci-failure.yml
+++ b/.github/workflows/debug-ci-failure.yml
@@ -28,7 +28,6 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
-  workflows: write
 
 jobs:
   debug:

--- a/.github/workflows/debug-ci-failure.yml
+++ b/.github/workflows/debug-ci-failure.yml
@@ -212,3 +212,12 @@ jobs:
             '```' \
             | timeout 1800 claude --print \
                 --allowedTools "Task,Read,Write,Edit,Bash,Glob,Grep,WebFetch,WebSearch"
+
+          # Fail the job if the agent did not write a success result.
+          # This catches push failures, agent crashes, and cases where the
+          # agent gave up without taking any action.
+          RESULT=$(cat /tmp/ci-debugger-result 2>/dev/null || echo "")
+          if [[ "$RESULT" != "success"* ]]; then
+            echo "::error::ci-debugger did not complete successfully: ${RESULT:-no result written}"
+            exit 1
+          fi

--- a/.github/workflows/debug-ci-failure.yml
+++ b/.github/workflows/debug-ci-failure.yml
@@ -28,6 +28,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  workflows: write
 
 jobs:
   debug:


### PR DESCRIPTION
## Summary

- The ci-debugger agent now writes to `/tmp/ci-debugger-result` as its last action: `success: ...` on every success path (fix pushed, PR opened, transient issue opened), `failure: <reason>` if it hits an error or gives up
- After `claude --print` exits, the workflow checks that file and fails the job if a success result was not written — catching push failures, agent crashes, and silent no-ops
- Adds a constraint to the agent: never attempt to modify `.github/workflows/` files, since `GITHUB_TOKEN` cannot push workflow changes; open an Issue instead

Generated with [Claude Code](https://claude.com/claude-code)