### PR TITLE
fix(ci): broaden PASS pattern to match ebuild-verifier output format

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -83,7 +83,7 @@ jobs:
             install phase without merging to the live filesystem. Report results." \
             --allowedTools "Agent,Read,Bash,Glob,Grep" | tee "$OUTFILE"
 
-          if grep -qE "Overall:.*PASS" "$OUTFILE"; then
+          if grep -qE "(Overall|Verification Results):.*PASS" "$OUTFILE"; then
             echo "result=pass" >> "$GITHUB_OUTPUT"
           else
             echo "result=fail" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

`verify.yml:86` checked for `Overall:.*PASS` but the `ebuild-verifier` agent outputs:

```
## Verification Results: dev-util/worktrunk-0.33.0 — PASS
```

The pattern never matched, so every successful verification was falsely reported as a failure and the auto-update PRs were never promoted from draft.

## Fix

Broadened the pattern to `(Overall|Verification Results):.*PASS`.

## Reference

Originally diagnosed by the ci-debugger agent on PR #27; could not be pushed automatically because `GITHUB_TOKEN` cannot modify workflow files.

Generated with [Claude Code](https://claude.com/claude-code)