### PR TITLE
fix(ci): fail job with diagnosis when fix requires a workflow file change

### DIFF
--- a/.claude/agents/ci-debugger.md
+++ b/.claude/agents/ci-debugger.md
@@ -236,6 +236,10 @@ echo "failure: <one-line reason>" > /tmp/ci-debugger-result
 - **Never** run `emerge`, `ebuild`, `pkgcheck`, or `pkgdev` — this runner is `ubuntu-latest` without a Gentoo environment.
 - **Never** open more than one PR or one Issue per invocation.
 - **Never** modify files under `.claude/` (agents, settings, skills).
-- **Never** modify files under `.github/workflows/` — `GITHUB_TOKEN` cannot push workflow file changes (requires a PAT with `workflow` scope). If the fix requires a workflow change, open a GitHub Issue describing the needed change instead of attempting a push.
+- **Never** modify files under `.github/workflows/` — `GITHUB_TOKEN` cannot push workflow file changes (requires a PAT with `workflow` scope). If the fix requires a workflow change, print the full diagnosis and the exact change needed to stdout, then write a failure result and stop:
+  ```bash
+  echo "failure: workflow file change required — <one-line description of the fix>" > /tmp/ci-debugger-result
+  ```
+  The job will fail visibly and the diagnosis will appear in the Actions log.
 - For verify failures: push to the existing auto-update branch, never create a new PR.
 - If in doubt between fixable and transient, choose transient.


### PR DESCRIPTION
## Summary

When the ci-debugger identifies a fix that requires modifying `.github/workflows/` (which `GITHUB_TOKEN` can't push), it previously did nothing — the job "succeeded" silently with no output.

Now it prints the full diagnosis and the exact change needed to stdout, then writes `failure: workflow file change required — …` to the result file. The job fails visibly and the todo is readable directly in the Actions log.

Generated with [Claude Code](https://claude.com/claude-code)