### PR TITLE
fix(ci): sign auto-update commits with GPG key

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -51,12 +51,18 @@ jobs:
         env:
           REPO: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
         run: |
           set -euo pipefail
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:$GITHUB_TOKEN@github.com/$REPO.git"
+
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec/{print $5; exit}')
+          git config --global user.signingkey "$KEY_ID"
+          git config --global commit.gpgsign true
 
       - name: Run ebuild-updater
         env:


### PR DESCRIPTION
## Summary

- Imports `GPG_PRIVATE_KEY` secret in the "Configure git" step of `auto-update.yml`
- Extracts the key ID and sets `user.signingkey` + `commit.gpgsign = true` globally
- All subsequent `git commit` calls in the job will now produce signed commits, satisfying the repository's signed-commit branch protection rule

## Prerequisites

Add the CI GPG private key as a repository secret named `GPG_PRIVATE_KEY`. To generate one:

```bash
# Generate a dedicated CI key (no passphrase — CI can't prompt)
gpg --batch --gen-key <<EOF
Key-Type: EdDSA
Key-Curve: ed25519
Name-Real: github-actions[bot]
Name-Email: github-actions[bot]@users.noreply.github.com
Expire-Date: 2y
%no-protection
EOF

# Export the private key
gpg --armor --export-secret-keys github-actions[bot]@users.noreply.github.com
```

Paste the output (including `-----BEGIN PGP PRIVATE KEY BLOCK-----`) as the `GPG_PRIVATE_KEY` secret value.

Optionally, export and add the public key to your GitHub account or the repo's trusted keys so GitHub shows the "Verified" badge on the commits.

## Test plan

- [ ] Add `GPG_PRIVATE_KEY` secret to the repo
- [ ] Trigger `auto-update.yml` manually via `workflow_dispatch`
- [ ] Confirm the resulting commit shows as "Verified" on GitHub

Generated with [Claude Code](https://claude.com/claude-code)