### PR TITLE
fix(ci): skip reinstalling already-installed packages in image build

### DIFF
--- a/.github/Containerfile.ci
+++ b/.github/Containerfile.ci
@@ -3,5 +3,5 @@ FROM ${BASE_IMAGE}
 
 RUN echo "net-libs/nodejs npm" >> /etc/portage/package.use/nodejs && \
     emerge-webrsync -q && \
-    emerge --quiet-build dev-vcs/git dev-util/pkgdev dev-util/pkgcheck dev-util/github-cli net-libs/nodejs dev-lang/go dev-lang/rust-bin && \
+    emerge --update --newuse --deep --quiet-build dev-vcs/git dev-util/pkgdev dev-util/pkgcheck dev-util/github-cli net-libs/nodejs dev-lang/go dev-lang/rust-bin && \
     npm install -g @anthropic-ai/claude-code


### PR DESCRIPTION
## Summary

- Add `--update --newuse --deep` to the `emerge` call in `Containerfile.ci`
- When the weekly build starts from the existing `gentoo-ci:latest` image, packages already at the current version are skipped instead of reinstalled
- Cold builds from `gentoo/stage3` are unaffected — all packages still get installed

## Test plan

- [ ] Trigger a manual `workflow_dispatch` on `Build CI Image` and verify it completes faster than a full reinstall

Generated with Claude Code