### PR TITLE
fix(ci): use emerge --sync and @world update for incremental image builds

### DIFF
--- a/.github/Containerfile.ci
+++ b/.github/Containerfile.ci
@@ -2,6 +2,7 @@ ARG BASE_IMAGE=gentoo/stage3:amd64-systemd
 FROM ${BASE_IMAGE}
 
 RUN echo "net-libs/nodejs npm" >> /etc/portage/package.use/nodejs && \
-    emerge-webrsync -q && \
-    emerge --update --newuse --deep --quiet-build dev-vcs/git dev-util/pkgdev dev-util/pkgcheck dev-util/github-cli net-libs/nodejs dev-lang/go dev-lang/rust-bin && \
+    emerge --sync && \
+    emerge -uvDN --with-bdeps=y --quiet-build @world && \
+    emerge --noreplace --quiet-build dev-vcs/git dev-util/pkgdev dev-util/pkgcheck dev-util/github-cli net-libs/nodejs dev-lang/go dev-lang/rust-bin && \
     npm install -g @anthropic-ai/claude-code


### PR DESCRIPTION
## Summary

- Replace `emerge-webrsync` with `emerge --sync` for incremental portage tree syncing (avoids downloading a full snapshot on every build)
- Add `emerge -uvDN --with-bdeps=y @world` to keep all system packages current — this naturally resolves blockers (e.g. the `shadow`/`coreutils` conflict) without needing to enumerate individual packages
- Use `emerge --noreplace` for CI-specific packages so they're installed if missing but skipped if already upgraded by the `@world` step

## Closes

Supersedes and renders #35 unnecessary — the `@world` update upgrades `shadow` automatically, resolving the `coreutils-9.9-r12` soft block.

Generated with [Claude Code](https://claude.com/claude-code)