### PR TITLE
fix(ci): trigger verify workflow on pull_request events for draft PRs

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches-ignore:
       - main
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 permissions:
@@ -92,14 +94,14 @@ jobs:
 
   promote:
     needs: verify
-    if: startsWith(github.ref_name, 'auto-update/')
+    if: startsWith(github.head_ref || github.ref_name, 'auto-update/')
     runs-on: ubuntu-latest
     steps:
       - name: Promote draft PR to ready
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          BRANCH: ${{ github.ref_name }}
+          BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Summary

- GitHub does not fire `push` events for commits made with `GITHUB_TOKEN`, so the auto-update bot's branch push never triggered `verify.yml`
- Add `pull_request: [opened, synchronize, reopened]` trigger so the workflow runs when the draft PR is created
- Fix concurrency group and `promote` job to use `github.head_ref` (available on PR events) with `github.ref_name` as fallback (push events)

## Test plan

- [ ] Merge this PR
- [ ] Verify that the next auto-update run (or manually re-push the `auto-update/dev-util-worktrunk` branch) triggers `verify.yml` on the draft PR
- [ ] Confirm the `promote` job promotes the PR to ready once checks pass

Generated with Claude Code