### PR TITLE
fix(ci): broaden PASS pattern to match verifier output format

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -85,7 +85,7 @@ jobs:
             install phase without merging to the live filesystem. Report results." \
             --allowedTools "Agent,Read,Bash,Glob,Grep" | tee "$OUTFILE"
 
-          if grep -qE "(Overall|Verification Results):.*PASS" "$OUTFILE"; then
+          if grep -qE "(Overall|Verification( Results)?):.*PASS" "$OUTFILE"; then
             echo "result=pass" >> "$GITHUB_OUTPUT"
           else
             echo "result=fail" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- The ebuild-verifier agent sometimes outputs a condensed heading like `## Verification: pkg-ver — PASS` instead of the template's separate `### Overall: PASS` line
- The previous grep pattern `(Overall|Verification Results):.*PASS` didn't match the `Verification:` variant, causing the verify job to fail even when verification succeeded
- Updated pattern to `(Overall|Verification( Results)?):.*PASS` which covers all observed output formats

## Root cause

Run [#24201230665](https://github.com/divoxx/gentoo-overlay/actions/runs/24201230665/job/70645091053) shows the verifier reported `## Verification: dev-util/worktrunk-0.34.1 — PASS` but the job still exited 1 because the grep found no match.

## Test plan

- [ ] Verify the workflow file diff looks correct
- [ ] Re-run or wait for next auto-update to confirm the promote job runs after a passing verify

Generated with Claude Code