### PR TITLE
fix(ci): use bash shell and capture stderr in verify step

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -72,6 +72,7 @@ jobs:
 
       - name: Run ebuild-verifier
         id: verify
+        shell: bash
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           PACKAGE: ${{ matrix.package }}
@@ -83,7 +84,7 @@ jobs:
             "Use the ebuild-verifier agent to run full verification for $PACKAGE. \
             Regenerate the Manifest if needed, run pkgcheck QA scan, and build through the \
             install phase without merging to the live filesystem. Report results." \
-            --allowedTools "Agent,Read,Bash,Glob,Grep" | tee "$OUTFILE"
+            --allowedTools "Agent,Read,Bash,Glob,Grep" 2>&1 | tee "$OUTFILE"
 
           if grep -qE "(Overall|Verification( Results)?):.*PASS" "$OUTFILE"; then
             echo "result=pass" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- The default shell for `run:` steps is `sh` (dash on Ubuntu), which does not support `pipefail`
- This caused `claude` failures to silently fall through to the grep check, reporting a misleading "no PASS found" failure
- The real error (`Credit balance is too low` in this case) was written to stderr and never captured

## Changes

- Add `shell: bash` to the `Run ebuild-verifier` step so `set -euo pipefail` is honoured — a crashing `claude` will now fail the pipeline immediately rather than silently
- Add `2>&1` redirect so error messages from `claude` (auth failures, credit exhaustion, etc.) are captured in `$OUTFILE` and visible in the job log

## Root cause of today's failure

Run [#24208210837](https://github.com/divoxx/gentoo-overlay/actions/runs/24208210837) failed with `Credit balance is too low` — the API key's credits were exhausted. The balance needs to be topped up to unblock PR #37.

Generated with Claude Code