### PR TITLE
feat: create auto-update commits via GitHub API for verified signatures

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -107,16 +107,63 @@ jobs:
         id: push
         env:
           PACKAGE: ${{ matrix.package }}
+          REPO: ${{ github.repository }}
+          BOT_TOKEN: ${{ steps.bot-token.outputs.token }}
         run: |
           set -euo pipefail
           CATEGORY="${PACKAGE%%/*}"
           NAME="${PACKAGE##*/}"
           BRANCH="auto-update/${CATEGORY}-${NAME}"
 
-          git checkout -b "$BRANCH"
+          # Stage all changes in the package directory
           git add "${CATEGORY}/${NAME}/"
-          git commit -m "auto-update: bump $PACKAGE"
-          git push origin "$BRANCH" --force-with-lease
+
+          # Build GitHub API tree entries for each staged file.
+          # Commits created via the API are auto-signed by GitHub (shows as Verified).
+          ENTRIES='[]'
+          while IFS=$'\t' read -r status file; do
+            if [[ "$status" == "D" ]]; then
+              # Deleted file: null sha removes it from the tree
+              ENTRIES=$(echo "$ENTRIES" | jq \
+                --arg path "$file" \
+                '. + [{"path": $path, "mode": "100644", "type": "blob", "sha": null}]')
+            else
+              MODE=$(git ls-files --stage "$file" | awk '{print $1}')
+              CONTENT=$(base64 -w0 < "$file")
+              BLOB_SHA=$(GH_TOKEN="$BOT_TOKEN" gh api "repos/$REPO/git/blobs" \
+                --method POST -f encoding=base64 -f "content=$CONTENT" --jq '.sha')
+              ENTRIES=$(echo "$ENTRIES" | jq \
+                --arg path "$file" --arg mode "$MODE" --arg sha "$BLOB_SHA" \
+                '. + [{"path": $path, "mode": $mode, "type": "blob", "sha": $sha}]')
+            fi
+          done < <(git diff --cached --name-status)
+
+          PARENT_SHA=$(git rev-parse HEAD)
+          BASE_TREE=$(git rev-parse "HEAD^{tree}")
+
+          NEW_TREE=$(jq -n \
+            --arg base_tree "$BASE_TREE" \
+            --argjson tree "$ENTRIES" \
+            '{"base_tree": $base_tree, "tree": $tree}' | \
+            GH_TOKEN="$BOT_TOKEN" gh api "repos/$REPO/git/trees" \
+              --method POST --input - --jq '.sha')
+
+          NEW_COMMIT=$(jq -n \
+            --arg message "auto-update: bump $PACKAGE" \
+            --arg tree "$NEW_TREE" \
+            --arg parent "$PARENT_SHA" \
+            '{"message": $message, "tree": $tree, "parents": [$parent]}' | \
+            GH_TOKEN="$BOT_TOKEN" gh api "repos/$REPO/git/commits" \
+              --method POST --input - --jq '.sha')
+
+          # Update existing branch ref or create it
+          if GH_TOKEN="$BOT_TOKEN" gh api "repos/$REPO/git/refs/heads/$BRANCH" &>/dev/null; then
+            GH_TOKEN="$BOT_TOKEN" gh api "repos/$REPO/git/refs/heads/$BRANCH" \
+              --method PATCH -F force=true -f sha="$NEW_COMMIT"
+          else
+            GH_TOKEN="$BOT_TOKEN" gh api "repos/$REPO/git/refs" \
+              --method POST -f ref="refs/heads/$BRANCH" -f sha="$NEW_COMMIT"
+          fi
 
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

Replaces `git commit` + `git push` in the auto-update workflow with GitHub API calls. Commits created via the API are auto-signed by GitHub server-side and show as **Verified**, satisfying the signed-commits branch protection rule.

## How it works

Instead of `git commit -m ... && git push`:
1. Stage changes with `git add` (same as before)
2. For each staged file: create a blob via `POST /git/blobs`
3. Create a new tree via `POST /git/trees` (inherits unchanged files from base tree; deleted files get `sha: null`)
4. Create a commit via `POST /git/commits` — GitHub auto-signs this
5. Update or create the branch ref via `PATCH/POST /git/refs`

## Test plan

- [ ] Trigger `auto-update` workflow manually and confirm the resulting commit shows as **Verified** on GitHub
- [ ] Confirm PR #37 (`auto-update/dev-util-worktrunk`) can be merged after the branch is updated by this workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)