### PR TITLE
fix: pipe blob content via temp file to avoid arg length limit

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -129,9 +129,12 @@ jobs:
                 '. + [{"path": $path, "mode": "100644", "type": "blob", "sha": null}]')
             else
               MODE=$(git ls-files --stage "$file" | awk '{print $1}')
-              CONTENT=$(base64 -w0 < "$file")
+              # Use a temp file to avoid "Argument list too long" for large files
+              TMPJSON=$(mktemp)
+              base64 -w0 < "$file" | jq -Rs '{"encoding":"base64","content":.}' > "$TMPJSON"
               BLOB_SHA=$(GH_TOKEN="$BOT_TOKEN" gh api "repos/$REPO/git/blobs" \
-                --method POST -f encoding=base64 -f "content=$CONTENT" --jq '.sha')
+                --method POST --input "$TMPJSON" --jq '.sha')
+              rm -f "$TMPJSON"
               ENTRIES=$(echo "$ENTRIES" | jq \
                 --arg path "$file" --arg mode "$MODE" --arg sha "$BLOB_SHA" \
                 '. + [{"path": $path, "mode": $mode, "type": "blob", "sha": $sha}]')


### PR DESCRIPTION
## Summary

Fixes the `Argument list too long` error in the auto-update commit step when processing large files (e.g. Go ebuilds with a large `EGO_SUM` array).

**Root cause:** base64-encoding a large file and passing it as a `-f content=...` flag to `gh api` exceeds the OS argument list limit.

**Fix:** pipe the base64 content through `jq` into a temp file and use `gh api --input` instead of `-f` flags.

## Test plan

- [ ] Trigger auto-update manually and confirm `dev-util/worktrunk` completes without the arg length error

🤖 Generated with [Claude Code](https://claude.ai/claude-code)