### PR TITLE
fix(ci): retry Portage sync once on transient manifest failure

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -52,7 +52,9 @@ jobs:
           token: ${{ steps.bot-token.outputs.token }}
 
       - name: Sync Portage tree
-        run: emerge --sync -q
+        run: |
+          emerge --sync -q || emerge --sync -q
+          eselect news read all
 
       - name: Configure git
         env:


### PR DESCRIPTION
## Summary

- Retry `emerge --sync` once on failure — transient manifest verification failures self-resolve on a second attempt
- Add `eselect news read all` to suppress unread news item warnings that clutter CI logs

Unrelated to recent API commit changes — this is a pre-existing flakiness in the Gentoo tree sync.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)