### PR TITLE
fix(ci): add jq to CI container image

### DIFF
--- a/.github/Containerfile.ci
+++ b/.github/Containerfile.ci
@@ -3,4 +3,4 @@ FROM ${BASE_IMAGE}
 
 RUN emerge --sync && \
     emerge -uvDN --with-bdeps=y --quiet-build @world && \
-    emerge --noreplace --quiet-build dev-vcs/git dev-util/pkgdev dev-util/pkgcheck dev-util/github-cli dev-lang/go dev-lang/rust-bin
+    emerge --noreplace --quiet-build dev-vcs/git dev-util/pkgdev dev-util/pkgcheck dev-util/github-cli dev-lang/go dev-lang/rust-bin app-misc/jq


### PR DESCRIPTION
## Summary

- Adds `app-misc/jq` to the CI container image (`Containerfile.ci`)
- Fixes auto-update job failures caused by `jq: command not found` (exit 127) in the "Commit and push update branch" step, which uses `jq` to build GitHub API payloads

## Test plan

- [ ] CI `build-image` workflow rebuilds the container with `jq` included
- [ ] Next `auto-update` run completes without `jq: command not found` errors

Generated with [Claude Code](https://claude.com/claude-code)