### PR TITLE
ci: shift auto-update schedule to :20 and add retry delay

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -2,8 +2,8 @@ name: Auto-Update Ebuilds
 
 on:
   schedule:
-    - cron: '0 6 * * 0'   # Sunday 06:00 UTC (3h after image build at 03:00)
-    - cron: '0 6 * * 3'   # Wednesday 06:00 UTC
+    - cron: '20 6 * * 0'  # Sunday 06:20 UTC (3h after image build at 03:00)
+    - cron: '20 6 * * 3'  # Wednesday 06:20 UTC
   workflow_dispatch:        # allow manual trigger for testing
 
 permissions:
@@ -53,7 +53,7 @@ jobs:
 
       - name: Sync Portage tree
         run: |
-          emerge --sync -q || emerge --sync -q
+          emerge --sync -q || { sleep 60 && emerge --sync -q; }
           eselect news read all
 
       - name: Configure git


### PR DESCRIPTION
## Summary

- Moves the auto-update cron from `0 6 * *` (top of hour) to `20 6 * *` (20 minutes past), placing the job in the quiet window between rsync mirror update cycles (~:00 and ~:30)
- Replaces the immediate retry (`|| emerge --sync -q`) with a 60 s delayed retry (`|| { sleep 60 && emerge --sync -q; }`) so the mirror has time to finish propagating before the second attempt

Closes #53

## Test plan

- [ ] Trigger `Auto-Update Ebuilds` via `workflow_dispatch` and confirm the sync step passes without manifest errors
- [ ] Confirm next two scheduled runs (Sun/Wed 06:20 UTC) produce zero manifest mismatch errors

Generated with [Claude Code](https://claude.com/claude-code)