### PR TITLE
ci: handle git rename events in auto-update commit loop

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -123,12 +123,26 @@ jobs:
           # Build GitHub API tree entries for each staged file.
           # Commits created via the API are auto-signed by GitHub (shows as Verified).
           ENTRIES='[]'
-          while IFS=$'\t' read -r status file; do
+          while IFS=$'\t' read -r status file new_file; do
             if [[ "$status" == "D" ]]; then
               # Deleted file: null sha removes it from the tree
               ENTRIES=$(echo "$ENTRIES" | jq \
                 --arg path "$file" \
                 '. + [{"path": $path, "mode": "100644", "type": "blob", "sha": null}]')
+            elif [[ "$status" == R* ]]; then
+              # Renamed file: remove old path, add new path
+              ENTRIES=$(echo "$ENTRIES" | jq \
+                --arg path "$file" \
+                '. + [{"path": $path, "mode": "100644", "type": "blob", "sha": null}]')
+              MODE=$(git ls-files --stage "$new_file" | awk '{print $1}')
+              TMPJSON=$(mktemp)
+              base64 -w0 < "$new_file" | jq -Rs '{"encoding":"base64","content":.}' > "$TMPJSON"
+              BLOB_SHA=$(GH_TOKEN="$BOT_TOKEN" gh api "repos/$REPO/git/blobs" \
+                --method POST --input "$TMPJSON" --jq '.sha')
+              rm -f "$TMPJSON"
+              ENTRIES=$(echo "$ENTRIES" | jq \
+                --arg path "$new_file" --arg mode "$MODE" --arg sha "$BLOB_SHA" \
+                '. + [{"path": $path, "mode": $mode, "type": "blob", "sha": $sha}]')
             else
               MODE=$(git ls-files --stage "$file" | awk '{print $1}')
               # Use a temp file to avoid "Argument list too long" for large files


### PR DESCRIPTION
## Summary

- `git diff --cached --name-status` emits three tab-separated fields for renames: `R<score>\t<old_path>\t<new_path>`
- The `while read -r status file` loop only captured two fields, so rename events fell into the default (`else`) branch, which tried to read `$file` (which held the old path) — a file that no longer exists at that path in the working tree
- This caused the "Commit and push update branch" step to fail for `dev-util/worktrunk` (run [#24950670016](https://github.com/divoxx/gentoo-overlay/actions/runs/24950670016))

**Fix:** add `new_file` to the `read` variables and an `R*` branch that nulls out the old path in the GitHub API tree and uploads the new file content.

## Test plan

- [ ] Trigger a manual auto-update run for a package that bumps a version (causes a rename)
- [ ] Confirm "Commit and push update branch" succeeds and the update branch contains the correct new ebuild

Generated with [Claude Code](https://claude.com/claude-code)