### PR TITLE
ci: accept ~amd64 keywords in container and use bot token for PRs

### DIFF
--- a/.github/Containerfile.ci
+++ b/.github/Containerfile.ci
@@ -1,6 +1,7 @@
 ARG BASE_IMAGE=gentoo/stage3:amd64-systemd
 FROM ${BASE_IMAGE}
 
-RUN emerge --sync && \
+RUN echo 'ACCEPT_KEYWORDS="~amd64"' >> /etc/portage/make.conf && \
+    emerge --sync && \
     emerge -uvDN --with-bdeps=y --quiet-build @world && \
     emerge --noreplace --quiet-build dev-vcs/git dev-util/pkgdev dev-util/pkgcheck dev-util/github-cli dev-lang/go dev-lang/rust-bin app-misc/jq

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -189,7 +189,7 @@ jobs:
       - name: Open draft PR (skip if one already exists)
         if: steps.changes.outputs.updated == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.bot-token.outputs.token }}
           PACKAGE: ${{ matrix.package }}
           BRANCH: ${{ steps.push.outputs.branch }}
           REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

- **Containerfile.ci**: set `ACCEPT_KEYWORDS="~amd64"` in `make.conf` before `emerge --sync` so the CI container can install `~amd64` toolchain packages (e.g. `dev-lang/rust-bin` 1.94+). This is equivalent to what `ebuildtester --unstable` does and is correct for a dedicated testing container that only exists to build `~amd64` overlay packages.

- **auto-update.yml**: switch the "Open draft PR" step from `GITHUB_TOKEN` to the bot token. GitHub silently suppresses cross-workflow events triggered by `GITHUB_TOKEN`, which was preventing `verify.yml` from firing on newly opened auto-update PRs. The `verify` workflow only ran once the auto-update job later re-pushed the branch (synchronize event). With the bot token, the `pull_request: opened` event correctly triggers `verify` immediately.

## Related

- PR #62 (worktrunk): verify failed because `worktrunk-0.46.1` requires `rustc 1.94` which is `~amd64` only — fixed by the Containerfile change.
- PR #63 (devpod): verify never ran at all — fixed by the bot token change. That PR will need a re-trigger after this merges (manual `workflow_dispatch` on auto-update or a force-push to the branch).

Generated with Claude Code