### PR TITLE
ci: disable namespace sandbox features in container

### DIFF
--- a/.github/Containerfile.ci
+++ b/.github/Containerfile.ci
@@ -2,6 +2,7 @@ ARG BASE_IMAGE=gentoo/stage3:amd64-systemd
 FROM ${BASE_IMAGE}
 
 RUN echo 'ACCEPT_KEYWORDS="~amd64"' >> /etc/portage/make.conf && \
+    echo 'FEATURES="-pid-sandbox -ipc-sandbox -network-sandbox"' >> /etc/portage/make.conf && \
     emerge --sync && \
     emerge -uvDN --with-bdeps=y --quiet-build @world && \
     emerge --noreplace --quiet-build dev-vcs/git dev-util/pkgdev dev-util/pkgcheck dev-util/github-cli dev-lang/go dev-lang/rust-bin app-misc/jq


### PR DESCRIPTION
## Summary

Adds `FEATURES="-pid-sandbox -ipc-sandbox -network-sandbox"` to the CI container's `make.conf`.

These portage features call `unshare(2)` to set up PID/IPC/network namespace isolation, which requires `CAP_SYS_ADMIN`. GitHub Actions containers don't have that capability, so every build logs:

```
Unable to unshare: EPERM (for FEATURES="pid-sandbox")
Unable to unshare: EPERM (for FEATURES="ipc-sandbox network-sandbox pid-sandbox")
```

Docker already provides namespace isolation at the container boundary, so disabling these inside the container is safe and is consistent with how `ebuildtester` configures its containers. The LD_PRELOAD-based `sandbox` and `usersandbox` features are left enabled.

Generated with Claude Code