### PR TITLE
ci: accept divoxx-bot[bot] in debug workflow PR author check

### DIFF
--- a/.github/workflows/debug-ci-failure.yml
+++ b/.github/workflows/debug-ci-failure.yml
@@ -129,8 +129,8 @@ jobs:
                 --repo "$REPO" \
                 -q '.[0].author.login // empty')
 
-              if [ "${PR_AUTHOR:-}" != "github-actions[bot]" ]; then
-                echo "PR on $HEAD_BRANCH was not created by github-actions[bot] (got: ${PR_AUTHOR:-none}) — skipping"
+              if [ "${PR_AUTHOR:-}" != "github-actions[bot]" ] && [ "${PR_AUTHOR:-}" != "divoxx-bot[bot]" ]; then
+                echo "PR on $HEAD_BRANCH was not created by a known bot (got: ${PR_AUTHOR:-none}) — skipping"
                 echo "skip=true" >> "$GITHUB_OUTPUT"
                 exit 0
               fi


### PR DESCRIPTION
## Summary

- Fixes the `debug-ci-failure.yml` idempotency check to accept `divoxx-bot[bot]` in addition to `github-actions[bot]` as a valid auto-update bot author

## Root cause

PR #64 switched the auto-update workflow from `GITHUB_TOKEN` to the bot token for opening PRs. This means all auto-update PRs since then are authored by `divoxx-bot[bot]`, not `github-actions[bot]`. The debug workflow's idempotency check still only accepted `github-actions[bot]`, so it silently set `skip=true` and never ran the agent on failures.

## Impact

PR #67 (`auto-update/dev-util-worktrunk`) hit this: verify passed, the promote step failed with exit code 1, debug CI triggered — but skipped due to this bug, leaving the PR stuck in draft. Manually promoted it as part of this fix.

_Generated with Claude Code_