### PR TITLE
ci: use bot token in verify promote and debug fix pushes

### DIFF
--- a/.github/workflows/debug-ci-failure.yml
+++ b/.github/workflows/debug-ci-failure.yml
@@ -45,10 +45,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate bot token
+        id: bot-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.BOT_APP_ID }}
+          private_key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.bot-token.outputs.token }}
 
       - name: Install Claude Code
         run: npm install -g @anthropic-ai/claude-code
@@ -56,13 +63,14 @@ jobs:
       - name: Configure git
         env:
           REPO: ${{ github.repository }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BOT_TOKEN: ${{ steps.bot-token.outputs.token }}
+          BOT_APP_ID: ${{ secrets.BOT_APP_ID }}
         run: |
           set -euo pipefail
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git"
+          git config --global user.name "divoxx-bot[bot]"
+          git config --global user.email "${BOT_APP_ID}+divoxx-bot[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${REPO}.git"
 
       - name: Resolve context
         id: ctx

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -106,9 +106,16 @@ jobs:
     if: startsWith(github.head_ref || github.ref_name, 'auto-update/')
     runs-on: ubuntu-latest
     steps:
+      - name: Generate bot token
+        id: bot-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.BOT_APP_ID }}
+          private_key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
       - name: Promote draft PR to ready
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.bot-token.outputs.token }}
           REPO: ${{ github.repository }}
           BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |


### PR DESCRIPTION
## Summary

- **`verify.yml`**: add `tibdex/github-app-token` step to the `promote` job so `gh pr ready` runs as `divoxx-bot` — `GITHUB_TOKEN` cannot call `markPullRequestReadyForReview` on PRs created by a different GitHub App
- **`debug-ci-failure.yml`**: mint a bot token before checkout and use it for the git remote, so commits pushed by the ci-debugger agent fire `pull_request: synchronize` on the target PR branch

## Root cause

Both failures trace back to PR #64 switching PR authorship from `github-actions[bot]` to `divoxx-bot[bot]`. That PR fixed the _open_ event, but two other places still used `GITHUB_TOKEN`:

1. The `promote` step tried to mark a divoxx-bot PR as ready — GitHub rejects this cross-app mutation even with `pull-requests: write`
2. The debug agent pushed ebuild fixes using `GITHUB_TOKEN` — GitHub suppresses `pull_request` events for pushes made by the same token that created the workflow run, so verify never re-fired

Both now follow the same `tibdex/github-app-token` → bot-token pattern already used in `auto-update.yml`.

## Related

- Diagnosed by ci-debugger on worktrunk run [25750721365](https://github.com/divoxx/gentoo-overlay/actions/runs/25750721365): `"verify.yml promote job must use BOT_APP_ID/BOT_APP_PRIVATE_KEY"`

_Generated with Claude Code_