### PR TITLE
ci: trigger debug workflow for all verify failures, not just auto-update

### DIFF
--- a/.github/workflows/debug-ci-failure.yml
+++ b/.github/workflows/debug-ci-failure.yml
@@ -31,17 +31,11 @@ permissions:
 
 jobs:
   debug:
-    # workflow_run: only fire for failures, and gate Verify Ebuilds to auto-update/** branches.
+    # workflow_run: only fire for failures.
     # workflow_dispatch: always run — the human explicitly requested it.
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (
-        github.event.workflow_run.conclusion == 'failure' &&
-        (
-          github.event.workflow_run.name != 'Verify Ebuilds' ||
-          startsWith(github.event.workflow_run.head_branch, 'auto-update/')
-        )
-      )
+      github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-latest
 
     steps:
@@ -126,10 +120,10 @@ jobs:
           set -euo pipefail
 
           if [ "$WORKFLOW_NAME" = "Verify Ebuilds" ]; then
-            # For manual dispatch, skip the PR-author check — the human explicitly requested this run.
-            if [ "$MANUAL" != "true" ]; then
-              # Only self-heal PRs that were actually opened by the auto-update bot.
-              # This guards against a human branch named auto-update/* triggering the debugger.
+            # For auto-update branches: guard against a human branch named auto-update/* by
+            # checking the PR was actually opened by a known bot. Skip manual dispatch — the
+            # human explicitly requested this run.
+            if [ "$MANUAL" != "true" ] && [[ "$HEAD_BRANCH" == auto-update/* ]]; then
               PR_AUTHOR=$(gh pr list \
                 --head "$HEAD_BRANCH" \
                 --state open \


### PR DESCRIPTION
## Summary

- Remove the `startsWith(auto-update/)` restriction from the `workflow_run` trigger condition — the debugger was silently skipped for any Verify Ebuilds failure on a non-auto-update branch (e.g. `add/media-sound/spotify-player`)
- Scope the bot-author idempotency guard to `auto-update/*` branches only — its purpose is to prevent running on a human branch that happens to be named `auto-update/something`, which doesn't apply to other branches

## Behaviour after this change

| Branch | Auto-triggered | Bot-author check | Agent action |
|--------|---------------|-----------------|--------------|
| `auto-update/*` | ✓ on failure | yes (guards against human-named branches) | fix in-place |
| any other branch | ✓ on failure | no | open GitHub Issue |
| any branch | manual dispatch | no | fix in-place or open issue |

The ci-debugger agent already distinguishes between auto-update and other branches when deciding whether to fix in-place or open an issue — this change just lets it get there for non-auto-update failures.

_Generated with Claude Code_