### PR TITLE
feat: include upstream release notes in auto-update PR descriptions

### DIFF
--- a/.claude/agents/ebuild-updater.md
+++ b/.claude/agents/ebuild-updater.md
@@ -95,7 +95,18 @@ Run `pkgcheck scan <category>/<name>` and fix any issues reported. Common checks
 
 Run `ebuild <path-to-new-ebuild> clean fetch unpack prepare configure compile` to confirm the new version builds successfully without installing it. Fix any build failures before reporting completion.
 
-### 9. Report Results
+### 9. Write Changelog
+
+Fetch the release notes for the new version and write them to `/tmp/pr-changelog.txt`.
+
+- **GitHub**: Use the release body from `https://api.github.com/repos/{owner}/{repo}/releases/tags/v{version}` (also try without the `v` prefix if the first returns 404). Use the `body` field. If there is no GitHub release (only a tag), skip this step.
+- **PyPI / crates.io / other**: skip — no standard release notes format.
+
+Format the file as markdown. Include only the release notes for the new version being bumped — not the full history. If the release body is empty or contains only boilerplate, skip writing the file.
+
+Do not write the file if there are no useful release notes to include.
+
+### 10. Report Results
 
 Provide a summary:
 

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -208,10 +208,23 @@ jobs:
             exit 0
           fi
 
-          BODY=$(printf '%s\n\n%s\n\n%s' \
-            "Automated upstream version bump for \`$PACKAGE\`." \
-            "Verification will run automatically via the verify workflow. The PR will be promoted from draft to ready when all checks pass." \
-            "Generated with [Claude Code](https://claude.com/claude-code)")
+          CHANGELOG=""
+          if [ -f /tmp/pr-changelog.txt ]; then
+            CHANGELOG=$(cat /tmp/pr-changelog.txt)
+          fi
+
+          if [ -n "$CHANGELOG" ]; then
+            BODY=$(printf '%s\n\n## What changed\n\n%s\n\n%s\n\n%s' \
+              "Automated upstream version bump for \`$PACKAGE\`." \
+              "$CHANGELOG" \
+              "Verification will run automatically via the verify workflow. The PR will be promoted from draft to ready when all checks pass." \
+              "Generated with [Claude Code](https://claude.com/claude-code)")
+          else
+            BODY=$(printf '%s\n\n%s\n\n%s' \
+              "Automated upstream version bump for \`$PACKAGE\`." \
+              "Verification will run automatically via the verify workflow. The PR will be promoted from draft to ready when all checks pass." \
+              "Generated with [Claude Code](https://claude.com/claude-code)")
+          fi
 
           gh pr create \
             --draft \


### PR DESCRIPTION
## Summary

- **`ebuild-updater.md`**: after bumping a version, the agent fetches the GitHub release body for the new tag and writes it to `/tmp/pr-changelog.txt`
- **`auto-update.yml`**: the "Open draft PR" step reads that file; if present, the PR body gains a `## What changed` section with the upstream release notes

## Behaviour

- **GitHub packages**: release notes are fetched from the GitHub releases API (`/releases/tags/v{version}`, falling back to without the `v`). Included if the body is non-empty and non-boilerplate.
- **PyPI / crates.io / other**: no standard release notes format — falls back to the existing plain body.
- **Tag-only releases (no release object)**: file not written, plain body used.

## Example output

```
Automated upstream version bump for `dev-util/worktrunk`.

## What changed

<upstream release notes here>

Verification will run automatically via the verify workflow...
```

_Generated with Claude Code_