### PR TITLE
ci: fix verify-ebuild dep installation + improve ci-debugger failure handling

### DIFF
--- a/.claude/agents/ci-debugger.md
+++ b/.claude/agents/ci-debugger.md
@@ -142,6 +142,7 @@ For transient failures: go to **Step 4 (Transient Path)**.
 | `emerge` package-not-found, USE flag conflict, or slot conflict | Fix `.github/Containerfile.ci` |
 | CLI tool missing from image (`gh`, `claude`, `pkgcheck`, `pkgdev`) | Fix `.github/Containerfile.ci` |
 | Workflow YAML syntax error or invalid field | Fix `.github/workflows/<name>.yml` |
+| `pkg-config exited with status code 1` / `system library … was not found` during `src_compile` | Fix `scripts/verify-ebuild.sh` (missing `--onlydeps` step) |
 
 For fixable failures: go to **Step 3 (Fix Path)**.
 
@@ -151,7 +152,21 @@ If you cannot confidently classify, treat as **transient** and note the ambiguit
 
 ---
 
-## Step 3: Fix Path — New Branch + PR
+## Step 3: Fix Path — Tracking Issue + Fix PR
+
+### 3a. Open a tracking issue first
+
+Set the body, then call `scripts/ci/create-tracking-issue.sh`:
+
+```bash
+ISSUE_TITLE="CI fixable failure: $WORKFLOW_NAME ($(date +%Y-%m-%d))"
+ISSUE_BODY="$(printf '## Failure Summary\n\nWorkflow **'"$WORKFLOW_NAME"'** (run [#'"$RUN_ID"']('"$RUN_URL"')) failed with a fixable infrastructure issue.\n\n## Root Cause\n\n<classification and the key log lines that support it>\n\n## Fix\n\n<what file will be changed and why it prevents recurrence>\n\nGenerated with [Claude Code](https://claude.com/claude-code)')"
+
+ISSUE_URL=$(ISSUE_TITLE="$ISSUE_TITLE" ISSUE_BODY="$ISSUE_BODY" bash scripts/ci/create-tracking-issue.sh)
+ISSUE_NUMBER="${ISSUE_URL##*/}"
+```
+
+### 3b. Create the fix branch and make the code change
 
 Use the exact fix branch name from your context (`FIX_BRANCH`). Do not invent a different name.
 
@@ -169,6 +184,12 @@ git checkout -b "$FIX_BRANCH"
 - Read the failing workflow file in full before editing.
 - YAML is whitespace-sensitive; validate indentation carefully.
 
+**`scripts/verify-ebuild.sh` fixes:**
+- The build failed because declared DEPENDs were not installed before `ebuild … compile`.
+- Add a "4/5" step between fetch and build that calls `emerge --onlydeps --quiet-build "=${CATEGORY}/${NAME}-${PV}::${REPO_NAME}"`.
+- Derive `REPO_NAME` from `cat "$OVERLAY_ROOT/profiles/repo_name"` and `PV` from the ebuild filename: `EBUILD_BASENAME=$(basename "$EBUILD_FILE" .ebuild); PV="${EBUILD_BASENAME#${NAME}-}"`.
+- File to edit: `scripts/verify-ebuild.sh`.
+
 Make your edits, then commit and push:
 
 ```bash
@@ -177,21 +198,22 @@ git commit -m "ci: <short description of what was broken and how it is fixed>"
 git push origin "$FIX_BRANCH" --force-with-lease
 ```
 
-Open a PR — **not** a draft:
+### 3c. Open the fix PR (not a draft)
+
+Set the body, then call `scripts/ci/open-fix-pr.sh`:
 
 ```bash
-gh pr create \
-  --title "ci-fix: <short description>" \
-  --body "$(printf '## Problem\n\n<one paragraph: what failed and why>\n\n## Fix\n\n<one paragraph: what was changed and why it prevents recurrence>\n\n## Reference\n\nFailed run: '"$RUN_URL"'\n\nGenerated with [Claude Code](https://claude.com/claude-code)')" \
-  --base main \
-  --head "$FIX_BRANCH" \
-  --repo "$REPO"
+PR_TITLE="ci-fix: <short description>"
+PR_BODY="$(printf '## Problem\n\n<one paragraph: what failed and why>\n\n## Fix\n\n<one paragraph: what was changed and why it prevents recurrence>\n\n## Reference\n\nFailed run: '"$RUN_URL"'\nTracking issue: '"$ISSUE_URL"'\n\nCloses #'"$ISSUE_NUMBER"'\n\nGenerated with [Claude Code](https://claude.com/claude-code)')"
+
+FIX_PR_URL=$(PR_TITLE="$PR_TITLE" PR_BODY="$PR_BODY" bash scripts/ci/open-fix-pr.sh)
 ```
 
-After a successful push and PR creation, write the result and print a summary:
+After a successful push and PR creation, write the result and set `ARTIFACT_URLS` for Step 5, then go to Step 5:
 
 ```bash
-echo "success: PR opened at <pr-url>" > /tmp/ci-debugger-result
+echo "success: issue $ISSUE_URL, fix PR $FIX_PR_URL" > /tmp/ci-debugger-result
+ARTIFACT_URLS="tracking issue: $ISSUE_URL — fix PR: $FIX_PR_URL"
 ```
 
 If the push or PR creation fails, write a failure result before stopping:
@@ -204,28 +226,43 @@ echo "failure: <one-line reason>" > /tmp/ci-debugger-result
 
 ## Step 4: Transient Path — GitHub Issue
 
-Do not push any branch or open a PR. Open a GitHub Issue instead:
+Do not push any branch or open a PR. Open a GitHub Issue instead using `scripts/ci/create-tracking-issue.sh`. The script automatically skips the `--label` flag if the label does not exist:
 
 ```bash
-gh issue create \
-  --title "CI transient failure: $WORKFLOW_NAME ($(date +%Y-%m-%d))" \
-  --body "$(printf '## Failure Summary\n\nWorkflow **'"$WORKFLOW_NAME"'** (run [#'"$RUN_ID"']('"$RUN_URL"')) failed with a transient error that does not require a code fix.\n\n## Root Cause\n\n<classification and the key log lines that support it>\n\n## Recommendation\n\nRe-trigger the workflow manually once the underlying condition resolves. No code change is needed.\n\nGenerated with [Claude Code](https://claude.com/claude-code)')" \
-  --label "ci-transient" \
-  --repo "$REPO"
+ISSUE_TITLE="CI transient failure: $WORKFLOW_NAME ($(date +%Y-%m-%d))"
+ISSUE_BODY="$(printf '## Failure Summary\n\nWorkflow **'"$WORKFLOW_NAME"'** (run [#'"$RUN_ID"']('"$RUN_URL"')) failed with a transient error that does not require a code fix.\n\n## Root Cause\n\n<classification and the key log lines that support it>\n\n## Recommendation\n\nRe-trigger the workflow manually once the underlying condition resolves. No code change is needed.\n\nGenerated with [Claude Code](https://claude.com/claude-code)')"
+
+ISSUE_URL=$(ISSUE_TITLE="$ISSUE_TITLE" ISSUE_BODY="$ISSUE_BODY" ISSUE_LABEL="ci-transient" bash scripts/ci/create-tracking-issue.sh)
 ```
 
-If the `ci-transient` label does not exist, omit `--label` — do not attempt to create labels.
-
-After a successful issue creation, write the result:
+After a successful issue creation, set `ARTIFACT_URLS` and go to Step 5:
 
 ```bash
-echo "success: transient issue opened" > /tmp/ci-debugger-result
+ARTIFACT_URLS="transient issue: $ISSUE_URL"
+echo "success: transient issue opened at $ISSUE_URL" > /tmp/ci-debugger-result
 ```
 
 If issue creation fails, write a failure result before stopping:
 
 ```bash
 echo "failure: <one-line reason>" > /tmp/ci-debugger-result
+```
+
+---
+
+## Step 5: Comment on the Triggering PR
+
+After completing Step 3 or Step 4, call `scripts/ci/comment-triggering-pr.sh`. It silently exits 0 if no open PR exists for `HEAD_BRANCH`.
+
+`COMMENT_BODY` values:
+- **Fixable (Step 3):** `ARTIFACT_URLS` = `"tracking issue: $ISSUE_URL — fix PR: $FIX_PR_URL"`
+- **Transient (Step 4):** `ARTIFACT_URLS` = `"transient issue: $ISSUE_URL"`
+
+```bash
+COMMENT_BODY="$(printf 'The CI verify failure on this PR has been diagnosed.\n\n%s\n\nNo action needed on your end — this PR will be re-verified once the fix lands (fixable) or can be re-triggered manually (transient).\n\nGenerated with [Claude Code](https://claude.com/claude-code)' "$ARTIFACT_URLS")"
+
+COMMENT_BODY="$COMMENT_BODY" bash scripts/ci/comment-triggering-pr.sh || \
+  echo "Warning: failed to comment on triggering PR — continuing" >&2
 ```
 
 ---

--- a/scripts/ci/comment-triggering-pr.sh
+++ b/scripts/ci/comment-triggering-pr.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Post a comment on the open PR for HEAD_BRANCH, if one exists.
+# Silently exits 0 if no open PR is found — callers treat this as best-effort.
+#
+# Env vars:
+#   REPO          - GitHub repository (owner/name)
+#   HEAD_BRANCH   - Branch that triggered the CI failure
+#   COMMENT_BODY  - Comment text (markdown)
+
+set -euo pipefail
+
+: "${REPO:?REPO must be set}"
+: "${HEAD_BRANCH:?HEAD_BRANCH must be set}"
+: "${COMMENT_BODY:?COMMENT_BODY must be set}"
+
+PR_NUMBER=$(gh pr list \
+    --head "$HEAD_BRANCH" \
+    --state open \
+    --json number \
+    --repo "$REPO" \
+    -q '.[0].number // empty')
+
+if [[ -z "$PR_NUMBER" ]]; then
+    echo "No open PR for branch '$HEAD_BRANCH' in $REPO — skipping comment" >&2
+    exit 0
+fi
+
+gh pr comment "$PR_NUMBER" \
+    --repo "$REPO" \
+    --body "$COMMENT_BODY"
+
+echo "Commented on PR #$PR_NUMBER" >&2

--- a/scripts/ci/create-tracking-issue.sh
+++ b/scripts/ci/create-tracking-issue.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Create a GitHub tracking issue and print its URL to stdout.
+#
+# Env vars:
+#   REPO          - GitHub repository (owner/name)
+#   ISSUE_TITLE   - Issue title
+#   ISSUE_BODY    - Issue body (markdown)
+#   ISSUE_LABEL   - (optional) label to apply; skipped if label doesn't exist
+
+set -euo pipefail
+
+: "${REPO:?REPO must be set}"
+: "${ISSUE_TITLE:?ISSUE_TITLE must be set}"
+: "${ISSUE_BODY:?ISSUE_BODY must be set}"
+
+LABEL_ARGS=()
+if [[ -n "${ISSUE_LABEL:-}" ]]; then
+    # Check label exists before attempting to apply it.
+    if gh label list --repo "$REPO" --json name -q '.[].name' | grep -qx "$ISSUE_LABEL"; then
+        LABEL_ARGS=(--label "$ISSUE_LABEL")
+    else
+        echo "Warning: label '$ISSUE_LABEL' does not exist in $REPO — skipping" >&2
+    fi
+fi
+
+gh issue create \
+    --title "$ISSUE_TITLE" \
+    --body "$ISSUE_BODY" \
+    "${LABEL_ARGS[@]}" \
+    --repo "$REPO"

--- a/scripts/ci/open-fix-pr.sh
+++ b/scripts/ci/open-fix-pr.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Open a fix PR and print its URL to stdout.
+#
+# Env vars:
+#   REPO          - GitHub repository (owner/name)
+#   FIX_BRANCH    - Head branch for the PR
+#   PR_TITLE      - PR title
+#   PR_BODY       - PR body (markdown)
+#   BASE_BRANCH   - (optional) base branch; defaults to "main"
+
+set -euo pipefail
+
+: "${REPO:?REPO must be set}"
+: "${FIX_BRANCH:?FIX_BRANCH must be set}"
+: "${PR_TITLE:?PR_TITLE must be set}"
+: "${PR_BODY:?PR_BODY must be set}"
+
+BASE="${BASE_BRANCH:-main}"
+
+gh pr create \
+    --title "$PR_TITLE" \
+    --body "$PR_BODY" \
+    --base "$BASE" \
+    --head "$FIX_BRANCH" \
+    --repo "$REPO"

--- a/scripts/verify-ebuild.sh
+++ b/scripts/verify-ebuild.sh
@@ -50,7 +50,8 @@ if [[ -z "$OVERLAY_ROOT" ]]; then
 fi
 [[ -n "$OVERLAY_ROOT" ]] || die "Could not locate overlay root"
 
-echo "Overlay: $OVERLAY_ROOT ($(cat "$OVERLAY_ROOT/profiles/repo_name"))"
+REPO_NAME=$(cat "$OVERLAY_ROOT/profiles/repo_name")
+echo "Overlay: $OVERLAY_ROOT ($REPO_NAME)"
 
 # ---------------------------------------------------------------------------
 # Locate ebuild
@@ -72,19 +73,19 @@ fi
 echo "Ebuild: $EBUILD_FILE"
 
 # ---------------------------------------------------------------------------
-# 1/4: Manifest
+# 1/5: Manifest
 # ---------------------------------------------------------------------------
 
-step "1/4: Regenerating Manifest (pkgdev manifest)"
+step "1/5: Regenerating Manifest (pkgdev manifest)"
 
 (cd "$PKG_DIR" && pkgdev manifest)
 echo "Manifest: OK"
 
 # ---------------------------------------------------------------------------
-# 2/4: pkgcheck QA scan
+# 2/5: pkgcheck QA scan
 # ---------------------------------------------------------------------------
 
-step "2/4: pkgcheck QA scan"
+step "2/5: pkgcheck QA scan"
 
 # Run from overlay root so pkgcheck resolves the repo correctly.
 # Any finding (warning or error) is treated as a failure.
@@ -95,10 +96,10 @@ PKGCHECK_EXIT=0
 echo "pkgcheck: OK (no issues)"
 
 # ---------------------------------------------------------------------------
-# 3/4: Fetch
+# 3/5: Fetch
 # ---------------------------------------------------------------------------
 
-step "3/4: Fetching distfiles (ebuild clean fetch)"
+step "3/5: Fetching distfiles (ebuild clean fetch)"
 
 FETCH_LOG=$(mktemp /tmp/verify-fetch-XXXXXX.log)
 FETCH_EXIT=0
@@ -115,10 +116,25 @@ rm -f "$FETCH_LOG"
 echo "fetch: OK"
 
 # ---------------------------------------------------------------------------
-# 4/4: Build through install phase
+# 4/5: Install declared build dependencies
 # ---------------------------------------------------------------------------
 
-step "4/4: Building through install phase (unpack prepare configure compile install)"
+step "4/5: Installing build dependencies (emerge --onlydeps)"
+echo "Note: installs DEPEND/BDEPEND packages so pkg-config and headers are available."
+
+EBUILD_BASENAME=$(basename "$EBUILD_FILE" .ebuild)
+PV="${EBUILD_BASENAME#${NAME}-}"
+
+emerge --onlydeps --quiet-build "=${CATEGORY}/${NAME}-${PV}::${REPO_NAME}" || \
+    die "emerge --onlydeps failed — check DEPEND/BDEPEND declarations"
+
+echo "deps: OK"
+
+# ---------------------------------------------------------------------------
+# 5/5: Build through install phase
+# ---------------------------------------------------------------------------
+
+step "5/5: Building through install phase (unpack prepare configure compile install)"
 echo "Note: 'install' writes to staging \${D} only — live filesystem is never touched."
 
 ebuild "$EBUILD_FILE" unpack prepare configure compile install || \


### PR DESCRIPTION
## Summary

- **`scripts/verify-ebuild.sh`**: add step 4/5 (`emerge --onlydeps`) to install `DEPEND`/`BDEPEND` before building, fixing `pkg-config` failures for packages that require system libraries (e.g. `media-libs/alsa-lib`)
- **`ci-debugger`**: recognize missing `--onlydeps` as a fixable CI infrastructure issue, not transient
- **`ci-debugger`**: create both a tracking issue **and** a fix PR (cross-linked) for fixable failures, instead of either/or
- **`ci-debugger`**: always comment back on the triggering PR after opening an issue or fix PR (new Step 5)
- **`scripts/ci/*.sh`**: extract `gh issue create`, `gh pr create`, and `gh pr comment` logic from inline agent bash into dedicated scripts (`create-tracking-issue.sh`, `open-fix-pr.sh`, `comment-triggering-pr.sh`)

Closes #72

## Test plan

- [ ] Re-run verify on `add/media-sound/spotify-player` — should pass with `alsa-lib` installed by `--onlydeps`
- [ ] Trigger `debug-ci-failure.yml` manually on a future pkg-config failure — confirm it creates a tracking issue + fix PR + comments on the triggering PR
- [ ] Trigger on a transient failure — confirm it creates an issue + comments on the triggering PR

Generated with [Claude Code](https://claude.com/claude-code)