### PR TITLE
ci: fix FIX_BRANCH naming for verify failures on non-auto-update branches

### DIFF
--- a/.github/workflows/debug-ci-failure.yml
+++ b/.github/workflows/debug-ci-failure.yml
@@ -119,11 +119,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ "$WORKFLOW_NAME" = "Verify Ebuilds" ]; then
-            # For auto-update branches: guard against a human branch named auto-update/* by
-            # checking the PR was actually opened by a known bot. Skip manual dispatch — the
-            # human explicitly requested this run.
-            if [ "$MANUAL" != "true" ] && [[ "$HEAD_BRANCH" == auto-update/* ]]; then
+          if [ "$WORKFLOW_NAME" = "Verify Ebuilds" ] && [[ "$HEAD_BRANCH" == auto-update/* ]]; then
+            # Auto-update branch: debugger fixes the ebuild in-place on the same branch.
+            # Guard against a human branch named auto-update/* — only process bot-created PRs.
+            if [ "$MANUAL" != "true" ]; then
               PR_AUTHOR=$(gh pr list \
                 --head "$HEAD_BRANCH" \
                 --state open \
@@ -149,7 +148,8 @@ jobs:
               echo "skip=false" >> "$GITHUB_OUTPUT"
             fi
           else
-            # For build-image / auto-update failures: skip if a ci-fix PR already exists today.
+            # For build-image, auto-update, and non-auto-update verify failures:
+            # skip if a ci-fix PR already exists today for the same workflow.
             SLUG=$(echo "$WORKFLOW_NAME" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | tr -cd '[:alnum:]-')
             DATE=$(date +%Y-%m-%d)
             BRANCH="ci-fix/${SLUG}-${DATE}"


### PR DESCRIPTION
## Problem

After #74 added the fixable-CI-infrastructure path for verify failures, `debug-ci-failure.yml` set `FIX_BRANCH=HEAD_BRANCH` for all "Verify Ebuilds" scenarios. When the ci-debugger tries to create a fix branch for a CI infrastructure issue, it gets `FIX_BRANCH=add/media-sound/spotify-player` — that branch already exists, so `git checkout -b` fails.

## Fix

Split the Verify Ebuilds idempotency case into two:

- **`auto-update/*` branches**: keep current behavior — `FIX_BRANCH=HEAD_BRANCH` so the ebuild fix is pushed back to the same PR branch (Step 2A)
- **All other branches**: generate `ci-fix/verify-ebuilds-YYYY-MM-DD` — same pattern as build-image/auto-update failures — so the ci-debugger has a valid new branch for any CI infrastructure fix

Also restores `divoxx-bot[bot]` to the auto-update branch author allowlist.

## Reference

Discovered while executing the test plan for #74.

Generated with [Claude Code](https://claude.com/claude-code)