### PR TITLE
ci: register overlay with portage before emerge --onlydeps

### DIFF
--- a/scripts/verify-ebuild.sh
+++ b/scripts/verify-ebuild.sh
@@ -125,6 +125,15 @@ echo "Note: installs DEPEND/BDEPEND packages so pkg-config and headers are avail
 EBUILD_BASENAME=$(basename "$EBUILD_FILE" .ebuild)
 PV="${EBUILD_BASENAME#${NAME}-}"
 
+# Register the overlay with portage so emerge can resolve the package atom.
+OVERLAY_CONF="/etc/portage/repos.conf/${REPO_NAME}.conf"
+if [[ ! -f "$OVERLAY_CONF" ]]; then
+    mkdir -p /etc/portage/repos.conf
+    printf '[%s]\nlocation = %s\nmasters = gentoo\nauto-sync = no\n' \
+        "$REPO_NAME" "$OVERLAY_ROOT" > "$OVERLAY_CONF"
+    echo "Registered overlay '$REPO_NAME' at $OVERLAY_ROOT"
+fi
+
 emerge --onlydeps --quiet-build "=${CATEGORY}/${NAME}-${PV}::${REPO_NAME}" || \
     die "emerge --onlydeps failed — check DEPEND/BDEPEND declarations"
 


### PR DESCRIPTION
## Problem

The `emerge --onlydeps` step added in #74 fails with:

```
emerge: there are no ebuilds to satisfy "=media-sound/spotify-player-0.23.0::divoxx-overlay".
```

The CI container doesn't pre-configure the checked-out overlay in `/etc/portage/repos.conf`, so portage can't resolve package atoms with `::divoxx-overlay`. The `ebuild` command in earlier steps works because it takes a direct file path, but `emerge` needs a registered repo.

## Fix

Before calling `emerge --onlydeps`, write a repos.conf entry for the overlay pointing to `$OVERLAY_ROOT` if one doesn't already exist.

## Reference

- Tracking issue: https://github.com/divoxx/gentoo-overlay/issues/72
- Previous fix PR: #74
- Failed verify run: https://github.com/divoxx/gentoo-overlay/actions/runs/25753377880

Generated with [Claude Code](https://claude.com/claude-code)