### PR TITLE
ci: two-pass emerge --onlydeps to handle USE flag conflicts

### DIFF
--- a/scripts/verify-ebuild.sh
+++ b/scripts/verify-ebuild.sh
@@ -134,7 +134,13 @@ if [[ ! -f "$OVERLAY_CONF" ]]; then
     echo "Registered overlay '$REPO_NAME' at $OVERLAY_ROOT"
 fi
 
-emerge --onlydeps --quiet-build "=${CATEGORY}/${NAME}-${PV}::${REPO_NAME}" || \
+# First pass: write any required USE-flag changes to package.use (non-fatal).
+emerge --onlydeps --autounmask=y --autounmask-write \
+    "=${CATEGORY}/${NAME}-${PV}::${REPO_NAME}" 2>&1 || true
+
+# Second pass: install with the updated config in effect.
+emerge --onlydeps --quiet-build \
+    "=${CATEGORY}/${NAME}-${PV}::${REPO_NAME}" || \
     die "emerge --onlydeps failed — check DEPEND/BDEPEND declarations"
 
 echo "deps: OK"


### PR DESCRIPTION
## Problem

`emerge --onlydeps` also installs RDEPEND packages, which for `spotify-player` pulls in `libnotify → virtual/notification-daemon → gtk+ → cairo`. The CI container has `cairo` installed without the `X` USE flag, causing autounmask conflicts that block the emerge.

Observed in: https://github.com/divoxx/gentoo-overlay/actions/runs/25754183830

## Fix

Two-pass approach:
1. `--autounmask-write` (non-fatal): writes the required USE flag overrides to `/etc/portage/package.use/autounmask`
2. Second emerge picks up those changes and installs cleanly

## Reference

- Tracking issue: https://github.com/divoxx/gentoo-overlay/issues/72
- Overlay registration fix: #76

Generated with [Claude Code](https://claude.com/claude-code)