### PR TITLE
ci: dispatch autounmask config changes before second emerge pass

### DIFF
--- a/scripts/verify-ebuild.sh
+++ b/scripts/verify-ebuild.sh
@@ -138,6 +138,10 @@ fi
 emerge --onlydeps --autounmask=y --autounmask-write \
     "=${CATEGORY}/${NAME}-${PV}::${REPO_NAME}" 2>&1 || true
 
+# Accept any written config changes. --autounmask-write creates ._cfg000X_ files
+# under CONFIG_PROTECT which are not active until dispatched.
+etc-update --automode -5 2>/dev/null || true
+
 # Second pass: install with the updated config in effect.
 emerge --onlydeps --quiet-build \
     "=${CATEGORY}/${NAME}-${PV}::${REPO_NAME}" || \


### PR DESCRIPTION
## Problem

`emerge --onlydeps --autounmask-write` creates `._cfg000X_` temp files under CONFIG_PROTECT rather than modifying the config files directly. The second emerge pass runs before those staged changes are dispatched, so it still sees unresolved USE flag requirements and fails:

```
Autounmask changes successfully written.
IMPORTANT: config file '/etc/portage/package.use/nodejs' needs updating.
...
ERROR: emerge --onlydeps failed — check DEPEND/BDEPEND declarations
```

## Fix

Add `etc-update --automode -5` between the two passes. This auto-accepts all pending config file updates (portage's `._cfg000X_` staged files) so the second pass sees the resolved USE flags.

## Reference

Failed run: https://github.com/divoxx/gentoo-overlay/actions/runs/25754917040

Generated with [Claude Code](https://claude.com/claude-code)