### PR TITLE
ci: forbid empty trigger commits, use gh workflow run instead

### DIFF
--- a/.claude/agents/ci-debugger.md
+++ b/.claude/agents/ci-debugger.md
@@ -279,4 +279,5 @@ COMMENT_BODY="$COMMENT_BODY" bash scripts/ci/comment-triggering-pr.sh || \
   ```
   The job will fail visibly and the diagnosis will appear in the Actions log.
 - For verify failures: push to the existing auto-update branch, never create a new PR.
+- **Never** push empty commits to re-trigger CI. Use `gh workflow run <workflow-file> --ref <branch> --repo "$REPO"` instead.
 - If in doubt between fixable and transient, choose transient.


### PR DESCRIPTION
## Problem

An empty `ci: re-trigger verify` commit was pushed to `auto-update/dev-util-worktrunk` to kick a stuck CI workflow. This left an unsigned, content-free commit on a bot-managed branch that required a force-push cleanup.

## Fix

Add an explicit constraint to the ci-debugger agent: never push empty commits to re-trigger CI. Instead use:

```bash
gh workflow run verify.yml --ref <branch> --repo "$REPO"
```

This triggers the workflow without touching the commit history.

Generated with [Claude Code](https://claude.com/claude-code)