### PR TITLE
ci: sign bot commits via GitHub API in ci-debugger

### DIFF
--- a/.claude/agents/ci-debugger.md
+++ b/.claude/agents/ci-debugger.md
@@ -97,11 +97,12 @@ The logs from `gh run view --log-failed` include pkgcheck output and build error
 
 ```bash
 git add <category>/<name>/
-git commit -m "ci: fix <category>/<name> verify failure — <one-line description>"
-git push origin "$HEAD_BRANCH" --force-with-lease
+MESSAGE="ci: fix <category>/<name> verify failure — <one-line description>" \
+  BRANCH="$HEAD_BRANCH" FORCE=true \
+  bash scripts/ci/git-commit-signed.sh
 ```
 
-The existing PR will pick up the new commit automatically. Do NOT open a new PR.
+`git-commit-signed.sh` creates the commit via the GitHub API so GitHub marks it as Verified. The existing PR will pick up the new commit automatically. Do NOT open a new PR.
 
 After a successful push, write the result and print a summary:
 
@@ -194,9 +195,12 @@ Make your edits, then commit and push:
 
 ```bash
 git add <files>
-git commit -m "ci: <short description of what was broken and how it is fixed>"
-git push origin "$FIX_BRANCH" --force-with-lease
+MESSAGE="ci: <short description of what was broken and how it is fixed>" \
+  BRANCH="$FIX_BRANCH" \
+  bash scripts/ci/git-commit-signed.sh
 ```
+
+`git-commit-signed.sh` creates the commit via the GitHub API so GitHub marks it as Verified.
 
 ### 3c. Open the fix PR (not a draft)
 

--- a/.github/workflows/debug-ci-failure.yml
+++ b/.github/workflows/debug-ci-failure.yml
@@ -186,6 +186,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BOT_TOKEN: ${{ steps.bot-token.outputs.token }}
           REPO: ${{ github.repository }}
           RUN_ID: ${{ steps.ctx.outputs.run_id }}
           RUN_URL: ${{ steps.ctx.outputs.run_url }}

--- a/scripts/ci/git-commit-signed.sh
+++ b/scripts/ci/git-commit-signed.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Create a GitHub-API commit for all currently staged git changes.
+# Commits created via the GitHub API are automatically signed (Verified) by GitHub.
+#
+# Env vars:
+#   REPO       - GitHub repository (owner/name)
+#   BOT_TOKEN  - GitHub App token with contents:write permission
+#   MESSAGE    - Commit message
+#   BRANCH     - Target branch (defaults to current local branch)
+#   FORCE      - If "true", force-update the ref even if it diverged
+
+set -euo pipefail
+
+: "${REPO:?REPO must be set}"
+: "${BOT_TOKEN:?BOT_TOKEN must be set}"
+: "${MESSAGE:?MESSAGE must be set}"
+BRANCH="${BRANCH:-$(git branch --show-current)}"
+FORCE="${FORCE:-false}"
+
+ENTRIES='[]'
+while IFS=$'\t' read -r status file new_file; do
+  if [[ "$status" == "D" ]]; then
+    ENTRIES=$(echo "$ENTRIES" | jq \
+      --arg path "$file" \
+      '. + [{"path": $path, "mode": "100644", "type": "blob", "sha": null}]')
+  elif [[ "$status" == R* ]]; then
+    ENTRIES=$(echo "$ENTRIES" | jq \
+      --arg path "$file" \
+      '. + [{"path": $path, "mode": "100644", "type": "blob", "sha": null}]')
+    MODE=$(git ls-files --stage "$new_file" | awk '{print $1}')
+    TMPJSON=$(mktemp)
+    base64 -w0 < "$new_file" | jq -Rs '{"encoding":"base64","content":.}' > "$TMPJSON"
+    BLOB_SHA=$(GH_TOKEN="$BOT_TOKEN" gh api "repos/$REPO/git/blobs" \
+      --method POST --input "$TMPJSON" --jq '.sha')
+    rm -f "$TMPJSON"
+    ENTRIES=$(echo "$ENTRIES" | jq \
+      --arg path "$new_file" --arg mode "$MODE" --arg sha "$BLOB_SHA" \
+      '. + [{"path": $path, "mode": $mode, "type": "blob", "sha": $sha}]')
+  else
+    MODE=$(git ls-files --stage "$file" | awk '{print $1}')
+    TMPJSON=$(mktemp)
+    base64 -w0 < "$file" | jq -Rs '{"encoding":"base64","content":.}' > "$TMPJSON"
+    BLOB_SHA=$(GH_TOKEN="$BOT_TOKEN" gh api "repos/$REPO/git/blobs" \
+      --method POST --input "$TMPJSON" --jq '.sha')
+    rm -f "$TMPJSON"
+    ENTRIES=$(echo "$ENTRIES" | jq \
+      --arg path "$file" --arg mode "$MODE" --arg sha "$BLOB_SHA" \
+      '. + [{"path": $path, "mode": $mode, "type": "blob", "sha": $sha}]')
+  fi
+done < <(git diff --cached --name-status)
+
+PARENT_SHA=$(git rev-parse HEAD)
+BASE_TREE=$(git rev-parse "HEAD^{tree}")
+
+NEW_TREE=$(jq -n \
+  --arg base_tree "$BASE_TREE" \
+  --argjson tree "$ENTRIES" \
+  '{"base_tree": $base_tree, "tree": $tree}' | \
+  GH_TOKEN="$BOT_TOKEN" gh api "repos/$REPO/git/trees" \
+    --method POST --input - --jq '.sha')
+
+NEW_COMMIT=$(jq -n \
+  --arg message "$MESSAGE" \
+  --arg tree "$NEW_TREE" \
+  --arg parent "$PARENT_SHA" \
+  '{"message": $message, "tree": $tree, "parents": [$parent]}' | \
+  GH_TOKEN="$BOT_TOKEN" gh api "repos/$REPO/git/commits" \
+    --method POST --input - --jq '.sha')
+
+if GH_TOKEN="$BOT_TOKEN" gh api "repos/$REPO/git/refs/heads/$BRANCH" &>/dev/null; then
+  GH_TOKEN="$BOT_TOKEN" gh api "repos/$REPO/git/refs/heads/$BRANCH" \
+    --method PATCH -F force="$FORCE" -f sha="$NEW_COMMIT"
+else
+  GH_TOKEN="$BOT_TOKEN" gh api "repos/$REPO/git/refs" \
+    --method POST -f ref="refs/heads/$BRANCH" -f sha="$NEW_COMMIT"
+fi
+
+echo "$NEW_COMMIT"


### PR DESCRIPTION
## Problem

`ci-debugger` was creating commits with `git commit` + `git push`, which produces unsigned commits. The branch protection rule requires signed commits, so these PRs were blocked from merging (see #90).

## Fix

- **`scripts/ci/git-commit-signed.sh`** — new helper that builds a commit via the GitHub REST API and updates the branch ref. GitHub automatically marks API-created commits as Verified, the same approach already used by `auto-update.yml`.
- **`.github/workflows/debug-ci-failure.yml`** — exposes `BOT_TOKEN` to the ci-debugger agent step so the script can authenticate API calls.
- **`.claude/agents/ci-debugger.md`** — replaces both `git commit`/`git push` blocks with `git add` + `bash scripts/ci/git-commit-signed.sh`.

## After merging

Re-trigger the `Debug CI Failure` workflow against PR #90's branch (via Actions → workflow_dispatch) to replace the unsigned commit with a signed one.

Generated with [Claude Code](https://claude.com/claude-code)