### PR TITLE
ci-fix: upgrade sys-apps/portage before @world to fix self-upgrade crash

### DIFF
--- a/.github/Containerfile.ci
+++ b/.github/Containerfile.ci
@@ -4,5 +4,6 @@ FROM ${BASE_IMAGE}
 RUN echo 'ACCEPT_KEYWORDS="~amd64"' >> /etc/portage/make.conf && \
     echo 'FEATURES="-pid-sandbox -ipc-sandbox -network-sandbox"' >> /etc/portage/make.conf && \
     emerge --sync && \
+    emerge -u1 --quiet-build sys-apps/portage && \
     emerge -uvDN --with-bdeps=y --quiet-build @world && \
     emerge --noreplace --quiet-build dev-vcs/git dev-util/pkgdev dev-util/pkgcheck dev-util/github-cli dev-lang/go dev-lang/rust-bin app-misc/jq


### PR DESCRIPTION
## Problem

The **Build CI Image** workflow failed during the container build. The single `emerge -uvDN --with-bdeps=y @world` pass upgraded `sys-apps/portage` in the same transaction as everything else. While portage migrated from python3.13 to python3.14, the running process could no longer import `portage.dbapi._SyncfsProcess` (relocated in the new layout), crashing the post-merge syncfs step with `ModuleNotFoundError` and failing the build with `buildah exit status 1`.

## Fix

Add a dedicated `emerge -u1 --quiet-build sys-apps/portage` pass before the full `@world` update in `.github/Containerfile.ci`. Portage now upgrades itself in isolation, so the running interpreter is replaced cleanly and the remainder of the build runs under the new, consistent portage. This is the canonical remedy for portage self-upgrades across interpreter/layout changes.

## Reference

Failed run: https://github.com/divoxx/gentoo-overlay/actions/runs/27082823928
Tracking issue: https://github.com/divoxx/gentoo-overlay/issues/89

Closes #89

Supersedes #90 (which had an unsigned commit and could not be merged).

Generated with [Claude Code](https://claude.com/claude-code)">